### PR TITLE
Fixed Issue with moving between widgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ dist/
 notes/
 markdoc/
 npdoc2md/
+*.*~
+ecui/


### PR DESCRIPTION
If widgets were put into a grid and not immediately next to each other it was impossible to move the cursor between them. To replicate use the code block below, issue originally found on Fedora Linux version 30.
```python
import py_cui
  
root = py_cui.PyCUI(10, 10)
root.add_button("Quit", 0, 0, command=exit)
root.add_label("info", 5, 0)
cb = root.add_checkbox_menu("Box", 0, 5)
cb.add_item("test1")
cb.add_item("test2")
root.add_label("info2", 8, 0)
root.add_label("info2", 5, 5)
root.add_label("info2", 0, 8)
root.add_label("info2", 0, 5)
root.start()
```

I think a case could be made for having the grid manager automatically put widgets closer together in a similar way to layout managers in some GUI interfaces, however this fix would work for now.

Fix tested on Fedora 31 and Windows 10, all tests passing