### PR TITLE
Fixed DEL key bug for handling last text line; Updated Authors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Primary Author(s):
 Contributor(s):
     Maciej Wlodek
     telday
+    Aaron Pierce

--- a/py_cui/widgets.py
+++ b/py_cui/widgets.py
@@ -1174,7 +1174,7 @@ class ScrollTextBlock(Widget):
 
         current_line = self.get_current_line()
 
-        if self.cursor_text_pos_x == len(current_line) and self.cursor_text_pos_y < len(self.text_lines):
+        if self.cursor_text_pos_x == len(current_line) and self.cursor_text_pos_y < len(self.text_lines) - 1:
             self.text_lines[self.cursor_text_pos_y] = self.text_lines[self.cursor_text_pos_y] + self.text_lines[self.cursor_text_pos_y + 1]
             self.text_lines = self.text_lines[:self.cursor_text_pos_y+1] + self.text_lines[self.cursor_text_pos_y + 2:]
         elif self.cursor_text_pos_x < len(current_line):


### PR DESCRIPTION
When in a text block if, `self.cursor_text_pos_y` was at the last position on `current_line` and you were also on the last line of `self.text_lines` you would get a crash and receive and error for trying to index outside of `self.text_lines`.