### PR TITLE
Added del key functionality to text box

### DIFF
--- a/py_cui/widgets.py
+++ b/py_cui/widgets.py
@@ -846,6 +846,12 @@ class TextBox(Widget):
                 self.cursor_x = self.cursor_x - 1
             self.cursor_text_pos = self.cursor_text_pos - 1
 
+    def delete_char(self):
+        """Deletes character to right of texbox cursor
+        """
+
+        if self.cursor_text_pos < len(self.text):
+            self.text = self.text[:self.cursor_text_pos] + self.text[self.cursor_text_pos + 1:]
 
     def handle_key_press(self, key_pressed):
         """Override of base handle key press function
@@ -863,6 +869,8 @@ class TextBox(Widget):
             self.move_right()
         elif key_pressed == py_cui.keys.KEY_BACKSPACE:
             self.erase_char()
+        elif key_pressed == py_cui.keys.KEY_DELETE:
+            self.delete_char()
         elif key_pressed == py_cui.keys.KEY_HOME:
             self.jump_to_start()
         elif key_pressed == py_cui.keys.KEY_END:


### PR DESCRIPTION
After resolving text block delete key bug, noticed text box didnt have any delete key functionality. I mirrored the implementation of the text block version, and included similar handle of key of backspace for the box. 