### PR TITLE
Key mapping feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,6 @@ notes/
 markdoc/
 npdoc2md/
 *.*~
-ecui/
+epy_cui/
+activate.bat
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ dist/
 notes/
 markdoc/
 npdoc2md/
-*.*~
+*~
 epy_cui/
 activate.bat
 *.swp

--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,6 @@ Primary Author(s):
 
 Contributor(s):
     Maciej Wlodek
-    telday
+    Ellis Wright (telday)
     Aaron Pierce
     Caleb Reese (cptbldbrd)

--- a/examples/autogit.py
+++ b/examples/autogit.py
@@ -35,13 +35,13 @@ class AutoGitCUI:
         self.root.set_title('Autogit v{} - {}'.format(__version__, os.path.basename(self.dir)))
 
         # Keybindings when in overview mode, and set info bar
-        self.root.add_key_command(py_cui.keys.KEY_R_LOWER, self.refresh_git_status)
-        self.root.add_key_command(py_cui.keys.KEY_L_LOWER, self.show_log)
-        self.root.add_key_command(py_cui.keys.KEY_A_LOWER, self.add_all)
-        self.root.add_key_command(py_cui.keys.KEY_E_LOWER, self.open_editor)
-        self.root.add_key_command(py_cui.keys.KEY_F_LOWER, self.fetch_branch)
-        self.root.add_key_command(py_cui.keys.KEY_P_LOWER, self.push_branch)
-        self.root.add_key_command(py_cui.keys.KEY_M_LOWER, self.show_menu)
+        self.root.add_key_command(py_cui.keys.Key.R_LOWER, self.refresh_git_status)
+        self.root.add_key_command(py_cui.keys.Key.L_LOWER, self.show_log)
+        self.root.add_key_command(py_cui.keys.Key.A_LOWER, self.add_all)
+        self.root.add_key_command(py_cui.keys.Key.E_LOWER, self.open_editor)
+        self.root.add_key_command(py_cui.keys.Key.F_LOWER, self.fetch_branch)
+        self.root.add_key_command(py_cui.keys.Key.P_LOWER, self.push_branch)
+        self.root.add_key_command(py_cui.keys.Key.M_LOWER, self.show_menu)
         self.root.set_status_bar_text('Quit - q | Refresh - r | Add all - a | Git log - l | Open Editor - e | Pull Branch - f | Push Branch - p')
 
         # Create the add files menu. Add color rules to color first characters based on git status
@@ -77,24 +77,24 @@ class AutoGitCUI:
         self.commit_message_box = self.root.add_text_box('Commit Message', 8, 2, column_span=6)
 
         # Key commands for our file menus. Enter will git add, Space will show diff
-        self.add_files_menu.add_key_command(py_cui.keys.KEY_ENTER, self.add_revert_file)
-        self.add_files_menu.add_key_command(py_cui.keys.KEY_SPACE, self.open_git_diff)
+        self.add_files_menu.add_key_command(py_cui.keys.Key.ENTER, self.add_revert_file)
+        self.add_files_menu.add_key_command(py_cui.keys.Key.SPACE, self.open_git_diff)
         self.add_files_menu.help_text = 'Enter - git add, Space - see diff, Arrows - scroll, Esc - exit'
 
         # Enter will show remote info
-        self.git_remotes_menu.add_key_command(py_cui.keys.KEY_ENTER, self.show_remote_info)
+        self.git_remotes_menu.add_key_command(py_cui.keys.Key.ENTER, self.show_remote_info)
 
         # Enter will show commit diff
-        self.git_commits_menu.add_key_command(py_cui.keys.KEY_ENTER, self.show_git_commit_diff)
+        self.git_commits_menu.add_key_command(py_cui.keys.Key.ENTER, self.show_git_commit_diff)
         self.git_commits_menu.add_text_color_rule(' ', py_cui.GREEN_ON_BLACK, 'notstartswith', match_type='region', region=[0,7], include_whitespace=True)
 
         # Enter will checkout 
-        self.branch_menu.add_key_command(py_cui.keys.KEY_ENTER, self.checkout_branch)
-        self.branch_menu.add_key_command(py_cui.keys.KEY_SPACE, self.show_log)
+        self.branch_menu.add_key_command(py_cui.keys.Key.ENTER, self.checkout_branch)
+        self.branch_menu.add_key_command(py_cui.keys.Key.SPACE, self.show_log)
 
         # Add commands for committing and branch checkout.
-        self.new_branch_textbox.add_key_command(py_cui.keys.KEY_ENTER, self.create_new_branch)
-        self.commit_message_box.add_key_command(py_cui.keys.KEY_ENTER, self.ask_to_commit)
+        self.new_branch_textbox.add_key_command(py_cui.keys.Key.ENTER, self.create_new_branch)
+        self.commit_message_box.add_key_command(py_cui.keys.Key.ENTER, self.ask_to_commit)
 
 
     def get_logo(self):

--- a/examples/multi_window_demo.py
+++ b/examples/multi_window_demo.py
@@ -25,7 +25,7 @@ class MultiWindowDemo:
 
         # Add a text box to the second widget set
         self.text_box_B = self.widget_set_B.add_text_box('Enter something', 0, 0, column_span=2)
-        self.text_box_B.add_key_command(py_cui.keys.KEY_ENTER, self.open_set_A)
+        self.text_box_B.add_key_command(py_cui.keys.Key.ENTER, self.open_set_A)
 
 
     def open_set_A(self):

--- a/examples/simple_todo_list.py
+++ b/examples/simple_todo_list.py
@@ -30,9 +30,9 @@ class SimpleTodoList:
         self.save_todo_button = self.master.add_button('Save',             7, 4, column_span=2,    command=self.save_todo_file)
 
         # add some custom keybindings
-        self.new_todo_textbox.add_key_command(          py_cui.keys.KEY_ENTER, self.push_and_reset)
-        self.todo_scroll_cell.add_key_command(          py_cui.keys.KEY_ENTER, self.mark_as_in_progress)
-        self.in_progress_scroll_cell.add_key_command(   py_cui.keys.KEY_ENTER, self.mark_as_done)
+        self.new_todo_textbox.add_key_command(          py_cui.keys.Key.ENTER, self.push_and_reset)
+        self.todo_scroll_cell.add_key_command(          py_cui.keys.Key.ENTER, self.mark_as_in_progress)
+        self.in_progress_scroll_cell.add_key_command(   py_cui.keys.Key.ENTER, self.mark_as_done)
         self.read_todo_file()
 
 

--- a/examples/snano.py
+++ b/examples/snano.py
@@ -26,15 +26,15 @@ class SuperNano:
         self.dir = dir
 
         # If we press 's' we want to save the opened file
-        self.root.add_key_command(py_cui.keys.KEY_S_LOWER, self.save_opened_file)
+        self.root.add_key_command(py_cui.keys.Key.S_LOWER, self.save_opened_file)
 
         # Add a file selection menu
         self.file_menu = self.root.add_scroll_menu('Directory Files', 0, 0, row_span=5, column_span=2)
 
         # With ENTER key press, we open the selected file or directory, DELETE will delete the selected file or directory
         # See the callback functions for how these operations are performed
-        self.file_menu.add_key_command(py_cui.keys.KEY_ENTER, self.open_file_dir)
-        self.file_menu.add_key_command(py_cui.keys.KEY_DELETE, self.delete_selected_file)
+        self.file_menu.add_key_command(py_cui.keys.Key.ENTER, self.open_file_dir)
+        self.file_menu.add_key_command(py_cui.keys.Key.DELETE, self.delete_selected_file)
 
         # To better distingusish directories, add a color rule that is used to color directory names green
         # First parameter is a regex, second is color, third is how the rule should check the regex against the line.
@@ -46,7 +46,7 @@ class SuperNano:
         self.current_dir_box.set_text(self.dir)
 
         # You can manually enter directory path, and ENTER will try to open it
-        self.current_dir_box.add_key_command(py_cui.keys.KEY_ENTER, self.open_new_directory)
+        self.current_dir_box.add_key_command(py_cui.keys.Key.ENTER, self.open_new_directory)
 
         # Function that opens initial directory
         self.open_new_directory()
@@ -56,7 +56,7 @@ class SuperNano:
 
         # Add a textbox for adding new files on ENTER key
         self.new_file_textbox = self.root.add_text_box('Add New File', 5, 0, column_span=2)
-        self.new_file_textbox.add_key_command(py_cui.keys.KEY_ENTER, self.add_new_file)
+        self.new_file_textbox.add_key_command(py_cui.keys.Key.ENTER, self.add_new_file)
 
 
     def open_new_directory(self):

--- a/py_cui/__init__.py
+++ b/py_cui/__init__.py
@@ -104,11 +104,9 @@ class PyCUI:
         list of keybindings to check against in the main CUI loop
     height, width : int
         height of the terminal in characters, width of terminal in characters
-    exit_key : key_code
-        a key code for a key that exits the CUI
     """
 
-    def __init__(self, num_rows, num_cols, auto_focus_buttons=True, exit_key=py_cui.keys.KEY_Q_LOWER):
+    def __init__(self, num_rows, num_cols, auto_focus_buttons=True):
         """Constructor for PyCUI class
         """
 
@@ -125,7 +123,7 @@ class PyCUI:
 
         # Add status and title bar
         self.title_bar = py_cui.statusbar.StatusBar(self.title, BLACK_ON_WHITE)
-        self.init_status_bar_text = 'Press - {} - to exit. Arrow Keys to move between widgets. Enter to enter focus mode.'.format(py_cui.keys.get_char_from_ascii(exit_key))
+        self.init_status_bar_text = 'Press - {} - to exit. Arrow Keys to move between widgets. Enter to enter focus mode.'.format(py_cui.keys.get_char_from_ascii(py_cui.keys.Key.Q_LOWER.value))
         self.status_bar = py_cui.statusbar.StatusBar(self.init_status_bar_text, BLACK_ON_WHITE)
 
         # Initialize grid, renderer, and widget dict
@@ -147,12 +145,21 @@ class PyCUI:
         self.post_loading_callback = None
 
         # Top level keybindings. Exit key is 'q' by default
-        self.keybindings = {}
-        self.exit_key = exit_key
+        self.key_map = py_cui.keys.KeyMap()
+        self.load_default_keymap()
 
         # Callback to fire when CUI is stopped.
         self.on_stop = None
 
+    def load_default_keymap(self):
+        stop_wrapper = lambda x: self.stop()
+        self.key_map.bind_key(key=py_cui.keys.Key.Q_LOWER, definition=stop_wrapper)
+        self.key_map.bind_key(key=py_cui.keys.Key.ESCAPE, definition=self.lose_focus)
+        self.key_map.bind_key(key=py_cui.keys.Key.ENTER, definition=self.select_widget)
+        self.key_map.bind_key(key=py_cui.keys.Key.UP_ARROW, definition=self.move_to_neighbor)
+        self.key_map.bind_key(key=py_cui.keys.Key.DOWN_ARROW, definition=self.move_to_neighbor)
+        self.key_map.bind_key(key=py_cui.keys.Key.LEFT_ARROW, definition=self.move_to_neighbor)
+        self.key_map.bind_key(key=py_cui.keys.Key.RIGHT_ARROW, definition=self.move_to_neighbor)
 
     def get_widget_set(self):
         """Gets widget set object from current widgets.
@@ -625,7 +632,7 @@ class PyCUI:
             row of current widget
         column : int
             column of current widget
-        direction : py_cui.keys.KEY_*
+        direction : py_cui.keys.Key.*
             The direction in which to search
 
         Returns
@@ -637,10 +644,10 @@ class PyCUI:
         start_widget = self.selected_widget
 
         # Find all the widgets in the given row or column
-        if direction in [py_cui.keys.KEY_DOWN_ARROW, py_cui.keys.KEY_UP_ARROW]:
+        if direction in [py_cui.keys.Key.DOWN_ARROW, py_cui.keys.Key.UP_ARROW]:
             widgets = [i.id for i in self.get_widgets_by_col(column)]
             vertical = True
-        elif direction in [py_cui.keys.KEY_RIGHT_ARROW, py_cui.keys.KEY_LEFT_ARROW]:
+        elif direction in [py_cui.keys.Key.RIGHT_ARROW, py_cui.keys.Key.LEFT_ARROW]:
             widgets = [i.id for i in self.get_widgets_by_row(row)]
             vertical = False
         else:
@@ -653,9 +660,9 @@ class PyCUI:
 
         # Find the widget and move from there
         current_index = widgets.index(start_widget)
-        if direction == py_cui.keys.KEY_UP_ARROW or direction == py_cui.keys.KEY_LEFT_ARROW:
+        if direction is py_cui.keys.Key.UP_ARROW or direction is py_cui.keys.Key.LEFT_ARROW:
             current_index -= 1
-        elif direction == py_cui.keys.KEY_DOWN_ARROW or direction == py_cui.keys.KEY_RIGHT_ARROW:
+        elif direction is py_cui.keys.Key.DOWN_ARROW or direction is py_cui.keys.Key.RIGHT_ARROW:
             current_index += 1
 
         if current_index >= len(widgets) or current_index < 0:
@@ -719,21 +726,6 @@ class PyCUI:
         widget.selected = True
         self.in_focused_mode = True
         self.status_bar.set_text(widget.get_help_text())
-
-
-    def add_key_command(self, key, command):
-        """Function that adds a keybinding to the CUI when in overview mode
-
-        Parameters
-        ----------
-        key : py_cui.keys.KEY_*
-            The key bound to the command
-        command : Function
-            A no-arg or lambda function to fire on keypress
-        """
-
-        self.keybindings[key] = command
-
 
     # Popup functions. Used to display messages, warnings, and errors to the user.
 
@@ -986,61 +978,79 @@ class PyCUI:
         except KeyboardInterrupt:
             exit()
 
+    def handle_lose_focus(self, key: py_cui.keys.Key):
+        """Moves the focus out of a widget if it is currently set in one
+
+        Parameters
+        ----------
+        key : Key
+            The key pressed to trigger this method
+        """
+        selected_widget = self.widgets[self.selected_widget]
+        if self.in_focused_mode and self.popup is None:
+            self.lose_focus()
+
+    def select_widget(self, key: py_cui.keys.Key):
+        """Attempts to put the user in focus to a widget
+        
+        Parameters
+        ----------
+        key : Key
+            The key pressed to trigger this method
+        """
+        selected_widget = self.widgets[self.selected_widget]
+
+        if self.popup is None and self.selected_widget is not None and selected_widget.is_selectable:
+            self.in_focused_mode = True
+            selected_widget.selected = True
+            # If autofocus buttons is selected, we automatically process the button command and reset to overview mode
+            if self.auto_focus_buttons and isinstance(selected_widget, widgets.Button):
+                self.in_focused_mode = False
+                selected_widget.selected = False
+                if selected_widget.command is not None:
+                    selected_widget.command()
+            else:
+                self.status_bar.set_text(selected_widget.get_help_text())
+
+    def move_to_neighbor(self, direction: py_cui.keys.Key):
+        """Attempts to move the cursor to one of the neighbor widgets based on the key pressed
+
+        Parameters
+        ----------
+        direction : py_cui.keys.Key
+            The directional key pressed
+        """
+        selected_widget = self.widgets[self.selected_widget]
+
+        neighbor = self.check_if_neighbor_exists(selected_widget.row, selected_widget.column, direction)
+        if neighbor:
+            selected_widget.selected = False
+            self.set_selected_widget(neighbor)
 
     def handle_key_presses(self, key_pressed):
         """Function that handles all main loop key presses.
 
         Parameters
         ----------
-        key_pressed : py_cui.keys.KEY_*
+        key_pressed : py_cui.keys.Key.*
             The key being pressed
         """
-
+        print(key_pressed.value, key_pressed.name)
         # Selected widget represents which widget is being hovered over, though not necessarily in focus mode
         if self.selected_widget is None:
             return
-        selected_widget = self.widgets[self.selected_widget]
-
-        # If we are in focus mode, the widget has all of the control of the keyboard except
-        # for the escape key, which exits focus mode.
-        if self.in_focused_mode and self.popup is None:
-            if key_pressed == py_cui.keys.KEY_ESCAPE:
-                self.status_bar.set_text(self.init_status_bar_text)
-                self.in_focused_mode = False
-                selected_widget.selected = False
-            else:
-                # widget handles remaining py_cui.keys
-                selected_widget.handle_key_press(key_pressed)
 
         # Otherwise, barring a popup, we are in overview mode, meaning that arrow py_cui.keys move between widgets, and Enter key starts focus mode
-        elif self.popup is None:
-            if key_pressed == py_cui.keys.KEY_ENTER and self.selected_widget is not None and selected_widget.is_selectable:
-                self.in_focused_mode = True
-                selected_widget.selected = True
-                # If autofocus buttons is selected, we automatically process the button command and reset to overview mode
-                if self.auto_focus_buttons and isinstance(selected_widget, widgets.Button):
-                    self.in_focused_mode = False
-                    selected_widget.selected = False
-                    if selected_widget.command is not None:
-                        selected_widget.command()
-                else:
-                    self.status_bar.set_text(selected_widget.get_help_text())
-            for key in self.keybindings.keys():
-                if key_pressed == key:
-                    command = self.keybindings[key]
-                    command()
-
-            # If not in focus mode, use the arrow py_cui.keys to move around the selectable widgets.
-            neighbor = None
-            if key_pressed == py_cui.keys.KEY_UP_ARROW or key_pressed == py_cui.keys.KEY_DOWN_ARROW or key_pressed == py_cui.keys.KEY_LEFT_ARROW or key_pressed == py_cui.keys.KEY_RIGHT_ARROW:
-                neighbor = self.check_if_neighbor_exists(selected_widget.row, selected_widget.column, key_pressed)
-            if neighbor is not None:
-                selected_widget.selected = False
-                self.set_selected_widget(neighbor)
-
+        if not self.popup and self.selected_widget and self.in_focused_mode:
+            self.widgets[self.selected_widget].handle_key_press(key_pressed)
+            print('processed widget handler')
         # if we have a popup, that takes key control from both overview and focus mode
         elif self.popup is not None:
+            print('popup handler')
             self.popup.handle_key_press(key_pressed)
+        else:
+            print('executing main keymap')
+            self.key_map.execute(key_pressed)
 
 
     def draw(self, stdscr):
@@ -1068,10 +1078,7 @@ class PyCUI:
             self.renderer.set_border_renderer_chars(self.border_characters)
 
         # Loop where key_pressed is the last character pressed. Wait for exit key while no popup or focus mode
-        while key_pressed != self.exit_key or self.in_focused_mode or self.popup is not None:
-
-            if self.stopped:
-                break
+        while not self.stopped or self.in_focused_mode or self.popup is not None:
 
             # Initialization and size adjustment
             stdscr.clear()
@@ -1093,7 +1100,12 @@ class PyCUI:
                 self.post_loading_callback = None
 
             # Handle keypresses
-            self.handle_key_presses(key_pressed)
+            if key_pressed != 0:
+                try:
+                    key = py_cui.keys.Key(key_pressed)
+                    self.handle_key_presses(key)
+                except ValueError as e:
+                    continue
 
             # Draw status/title bar, and all widgets. Selected widget will be bolded.
             self.draw_status_bars(stdscr, height, width)
@@ -1111,8 +1123,6 @@ class PyCUI:
                 time.sleep(0.25)
                 # Need to reset key_pressed, because otherwise the previously pressed key will be used.
                 key_pressed = 0
-            elif self.stopped:
-                key_pressed = self.exit_key
             else:
                 key_pressed = stdscr.getch()
 

--- a/py_cui/keys.py
+++ b/py_cui/keys.py
@@ -5,6 +5,7 @@
 """
 
 from sys import platform
+from typing import Callable
 import curses
 
 # Some simple helper functions
@@ -22,7 +23,6 @@ def get_ascii_from_char(char):
     ascii_code : int
         Ascii code of character
     """
-
     return ord(char)
 
 
@@ -39,90 +39,130 @@ def get_char_from_ascii(key_num):
     char : character
         character converted from ascii
     """
-    
     return chr(key_num)
 
+class KeyMap(object):
+    def __init__(self):
+        self._bindings = dict()
 
-# Supported py_cui keys
-KEY_ENTER       = get_ascii_from_char('\n')
-# Escape character is ascii #27
-KEY_ESCAPE      = 27
-KEY_SPACE       = get_ascii_from_char(' ')
-KEY_DELETE      = curses.KEY_DC
-KEY_TAB         = get_ascii_from_char('\t')
-KEY_UP_ARROW    = curses.KEY_UP
-KEY_DOWN_ARROW  = curses.KEY_DOWN
-KEY_LEFT_ARROW  = curses.KEY_LEFT
-KEY_RIGHT_ARROW = curses.KEY_RIGHT
-KEY_PAGE_UP     = curses.KEY_PPAGE
-KEY_PAGE_DOWN   = curses.KEY_NPAGE
-KEY_F1          = curses.KEY_F1
-KEY_F2          = curses.KEY_F2
-KEY_F3          = curses.KEY_F3
-KEY_F4          = curses.KEY_F4
-KEY_F5          = curses.KEY_F5
-KEY_F6          = curses.KEY_F6
-KEY_F7          = curses.KEY_F7
-KEY_F8          = curses.KEY_F8
-KEY_HOME        = curses.KEY_HOME
-KEY_END         = curses.KEY_END
-KEY_A_LOWER     = get_ascii_from_char('a')
-KEY_B_LOWER     = get_ascii_from_char('b')
-KEY_C_LOWER     = get_ascii_from_char('c')
-KEY_D_LOWER     = get_ascii_from_char('d')
-KEY_E_LOWER     = get_ascii_from_char('e')
-KEY_F_LOWER     = get_ascii_from_char('f')
-KEY_G_LOWER     = get_ascii_from_char('g')
-KEY_H_LOWER     = get_ascii_from_char('h')
-KEY_I_LOWER     = get_ascii_from_char('i')
-KEY_J_LOWER     = get_ascii_from_char('j')
-KEY_K_LOWER     = get_ascii_from_char('k')
-KEY_L_LOWER     = get_ascii_from_char('l')
-KEY_M_LOWER     = get_ascii_from_char('m')
-KEY_N_LOWER     = get_ascii_from_char('n')
-KEY_O_LOWER     = get_ascii_from_char('o')
-KEY_P_LOWER     = get_ascii_from_char('p')
-KEY_Q_LOWER     = get_ascii_from_char('q')
-KEY_R_LOWER     = get_ascii_from_char('r')
-KEY_S_LOWER     = get_ascii_from_char('s')
-KEY_T_LOWER     = get_ascii_from_char('t')
-KEY_U_LOWER     = get_ascii_from_char('u')
-KEY_V_LOWER     = get_ascii_from_char('v')
-KEY_W_LOWER     = get_ascii_from_char('w')
-KEY_X_LOWER     = get_ascii_from_char('x')
-KEY_Y_LOWER     = get_ascii_from_char('y')
-KEY_Z_LOWER     = get_ascii_from_char('z')
-KEY_A_UPPER     = get_ascii_from_char('A')
-KEY_B_UPPER     = get_ascii_from_char('B')
-KEY_C_UPPER     = get_ascii_from_char('C')
-KEY_D_UPPER     = get_ascii_from_char('D')
-KEY_E_UPPER     = get_ascii_from_char('E')
-KEY_F_UPPER     = get_ascii_from_char('F')
-KEY_G_UPPER     = get_ascii_from_char('G')
-KEY_H_UPPER     = get_ascii_from_char('H')
-KEY_I_UPPER     = get_ascii_from_char('I')
-KEY_J_UPPER     = get_ascii_from_char('J')
-KEY_K_UPPER     = get_ascii_from_char('K')
-KEY_L_UPPER     = get_ascii_from_char('L')
-KEY_M_UPPER     = get_ascii_from_char('M')
-KEY_N_UPPER     = get_ascii_from_char('N')
-KEY_O_UPPER     = get_ascii_from_char('O')
-KEY_P_UPPER     = get_ascii_from_char('P')
-KEY_Q_UPPER     = get_ascii_from_char('Q')
-KEY_R_UPPER     = get_ascii_from_char('R')
-KEY_S_UPPER     = get_ascii_from_char('S')
-KEY_T_UPPER     = get_ascii_from_char('T')
-KEY_U_UPPER     = get_ascii_from_char('U')
-KEY_V_UPPER     = get_ascii_from_char('V')
-KEY_W_UPPER     = get_ascii_from_char('W')
-KEY_X_UPPER     = get_ascii_from_char('X')
-KEY_Y_UPPER     = get_ascii_from_char('Y')
-KEY_Z_UPPER     = get_ascii_from_char('Z')
+    def bind_key(self, /, key: Key, *, match: Callable=None, definition: Callable=None, old: Key=None):
+        """Binds a key to either a function or a key that previously had a binding
 
-# Pressing backspace returns 8 on windows?
-if platform == 'win32':
-    KEY_BACKSPACE   = 8
-else:
-    KEY_BACKSPACE   = curses.KEY_BACKSPACE
+        Parameters
+        ----------
+        key : Key
+            The new key to bind
+        definition : Callable
+            The function to bind
+        old : Key
+            The already bound key to bind to
+        """
+        if not isinstance(key, Key):
+            raise ValueError(f"{key} is an invalid value for key")
+        if old and old.value not in self._bindings:
+            raise ValueError(f"{old} is not in the bindings list, cannot bind to it")
+        if not old and not definition:
+            raise ValueError(f"Either old or definition must be defined")
+        if old and definition:
+            raise ValueError(f"Cannot bind to both a key and a callable")
+        if old:
+            self._bindings[key.value] = self._bindings[old.value]
+        self._bindings[key.value] = definition
+    
+    def execute(self, key: Key):
+        if not isinstance(key, Key):
+            raise ValueError(f"{key} is an invalid value for key")
+        elif key not in self._bindings.keys():
+            raise ValueError(f"{key} is an invalid value for key")
 
+        self._bindings[key.value]()
 
+    def unbind(self, key: Key):
+        """Unbinds a key from the map
+
+        Parameters
+        ----------
+        key : Key
+            The key to unbind
+        """
+        while key.value in self._bindings:
+            del self._bindings[key.value]
+
+class Key(enum.Enum):
+    # Supported py_cui keys
+    KEY_ENTER       = get_ascii_from_char('\n')
+    # Escape character is ascii #27
+    KEY_ESCAPE      = 27
+    KEY_SPACE       = get_ascii_from_char(' ')
+    KEY_DELETE      = curses.KEY_DC
+    KEY_TAB         = get_ascii_from_char('\t')
+    KEY_UP_ARROW    = curses.KEY_UP
+    KEY_DOWN_ARROW  = curses.KEY_DOWN
+    KEY_LEFT_ARROW  = curses.KEY_LEFT
+    KEY_RIGHT_ARROW = curses.KEY_RIGHT
+    KEY_PAGE_UP     = curses.KEY_PPAGE
+    KEY_PAGE_DOWN   = curses.KEY_NPAGE
+    KEY_F1          = curses.KEY_F1
+    KEY_F2          = curses.KEY_F2
+    KEY_F3          = curses.KEY_F3
+    KEY_F4          = curses.KEY_F4
+    KEY_F5          = curses.KEY_F5
+    KEY_F6          = curses.KEY_F6
+    KEY_F7          = curses.KEY_F7
+    KEY_F8          = curses.KEY_F8
+    KEY_HOME        = curses.KEY_HOME
+    KEY_END         = curses.KEY_END
+    KEY_A_LOWER     = get_ascii_from_char('a')
+    KEY_B_LOWER     = get_ascii_from_char('b')
+    KEY_C_LOWER     = get_ascii_from_char('c')
+    KEY_D_LOWER     = get_ascii_from_char('d')
+    KEY_E_LOWER     = get_ascii_from_char('e')
+    KEY_F_LOWER     = get_ascii_from_char('f')
+    KEY_G_LOWER     = get_ascii_from_char('g')
+    KEY_H_LOWER     = get_ascii_from_char('h')
+    KEY_I_LOWER     = get_ascii_from_char('i')
+    KEY_J_LOWER     = get_ascii_from_char('j')
+    KEY_K_LOWER     = get_ascii_from_char('k')
+    KEY_L_LOWER     = get_ascii_from_char('l')
+    KEY_M_LOWER     = get_ascii_from_char('m')
+    KEY_N_LOWER     = get_ascii_from_char('n')
+    KEY_O_LOWER     = get_ascii_from_char('o')
+    KEY_P_LOWER     = get_ascii_from_char('p')
+    KEY_Q_LOWER     = get_ascii_from_char('q')
+    KEY_R_LOWER     = get_ascii_from_char('r')
+    KEY_S_LOWER     = get_ascii_from_char('s')
+    KEY_T_LOWER     = get_ascii_from_char('t')
+    KEY_U_LOWER     = get_ascii_from_char('u')
+    KEY_V_LOWER     = get_ascii_from_char('v')
+    KEY_W_LOWER     = get_ascii_from_char('w')
+    KEY_X_LOWER     = get_ascii_from_char('x')
+    KEY_Y_LOWER     = get_ascii_from_char('y')
+    KEY_Z_LOWER     = get_ascii_from_char('z')
+    KEY_A_UPPER     = get_ascii_from_char('A')
+    KEY_B_UPPER     = get_ascii_from_char('B')
+    KEY_C_UPPER     = get_ascii_from_char('C')
+    KEY_D_UPPER     = get_ascii_from_char('D')
+    KEY_E_UPPER     = get_ascii_from_char('E')
+    KEY_F_UPPER     = get_ascii_from_char('F')
+    KEY_G_UPPER     = get_ascii_from_char('G')
+    KEY_H_UPPER     = get_ascii_from_char('H')
+    KEY_I_UPPER     = get_ascii_from_char('I')
+    KEY_J_UPPER     = get_ascii_from_char('J')
+    KEY_K_UPPER     = get_ascii_from_char('K')
+    KEY_L_UPPER     = get_ascii_from_char('L')
+    KEY_M_UPPER     = get_ascii_from_char('M')
+    KEY_N_UPPER     = get_ascii_from_char('N')
+    KEY_O_UPPER     = get_ascii_from_char('O')
+    KEY_P_UPPER     = get_ascii_from_char('P')
+    KEY_Q_UPPER     = get_ascii_from_char('Q')
+    KEY_R_UPPER     = get_ascii_from_char('R')
+    KEY_S_UPPER     = get_ascii_from_char('S')
+    KEY_T_UPPER     = get_ascii_from_char('T')
+    KEY_U_UPPER     = get_ascii_from_char('U')
+    KEY_V_UPPER     = get_ascii_from_char('V')
+    KEY_W_UPPER     = get_ascii_from_char('W')
+    KEY_X_UPPER     = get_ascii_from_char('X')
+    KEY_Y_UPPER     = get_ascii_from_char('Y')
+    KEY_Z_UPPER     = get_ascii_from_char('Z')
+
+    KEY_BACKSPACE   = 8 if platform == 'win32' else curses.KEY_BACKSPACE

--- a/py_cui/keys.py
+++ b/py_cui/keys.py
@@ -139,7 +139,7 @@ class KeyMap(object):
     def __init__(self):
         self._bindings = dict()
 
-    def bind_key(self, /, key: Key, *, definition: Callable=None, old: Key=None):
+    def bind_key(self, key: Key, definition: Callable=None, old: Key=None):
         """Binds a key to either a function or a key that previously had a binding
 
         Parameters

--- a/py_cui/keys.py
+++ b/py_cui/keys.py
@@ -1,6 +1,6 @@
 """Module containing constants and helper functions for dealing with keys.
 
-@author:    Jakub Wlodek  
+@author:    Jakub Wlodek, Ellis Wright (telday)
 @created:   12-Aug-2019
 """
 

--- a/py_cui/keys.py
+++ b/py_cui/keys.py
@@ -44,6 +44,7 @@ def get_char_from_ascii(key_num):
 
 
 class Key(enum.Enum):
+    """Enum representing a Key internally"""
     # KeysSupported py_cui keys
     ENTER       = get_ascii_from_char('\n')
     #Esccape character is ascii #27
@@ -124,6 +125,13 @@ class Key(enum.Enum):
 
 
 class KeyMap(object):
+    """Represents a map of keys to functionality internally
+
+    Attributes
+    ----------
+    _bindings : dict
+        The list of bindings
+    """
     def __init__(self):
         self._bindings = dict()
 
@@ -153,6 +161,13 @@ class KeyMap(object):
             self._bindings[key.value] = (definition, key)
     
     def execute(self, key: Key):
+        """Execute the given key on this map
+
+        Parameters
+        ----------
+        key : Key
+            The key to execute
+        """
         if not isinstance(key, Key):
             raise ValueError(f"{key} is an invalid value for key")
         elif key.value not in self._bindings.keys():
@@ -180,13 +195,38 @@ class KeyMap(object):
             return k
 
 class RawKeyMap(object):
+    """
+    A keymap for mapping large amounts of characters to
+    a single action/definition
+
+    Attributes
+    ----------
+    char_range : range
+        The range of characters to map
+    definition : Callable
+        The function to call on execution
+    """
     def __init__(self, char_range: range):
         self.char_range = char_range
         self.definition = None
 
     def add_definition(self, definition):
+        """Add a definition/function to this RawKeyMap
+
+        Parameters
+        ----------
+        definition : Callable
+            The definition to add
+        """
         self.definition = definition
 
     def execute(self, key: int):
+        """Execute this keymap on the given key
+
+        Parameters
+        ----------
+        key : int
+            The key to execute
+        """
         if key in self.char_range and self.definition:
             self.definition(key)

--- a/py_cui/keys.py
+++ b/py_cui/keys.py
@@ -7,6 +7,7 @@
 from sys import platform
 from typing import Callable
 import curses
+import enum
 
 # Some simple helper functions
 
@@ -41,11 +42,92 @@ def get_char_from_ascii(key_num):
     """
     return chr(key_num)
 
+
+class Key(enum.Enum):
+    # KeysSupported py_cui keys
+    ENTER       = get_ascii_from_char('\n')
+    #Esccape character is ascii #27
+    ESCAPE      = 27
+    SPACE       = get_ascii_from_char(' ')
+    DELETE      = curses.KEY_DC
+    TAB         = get_ascii_from_char('\t')
+    UP_ARROW    = curses.KEY_UP
+    DOWN_ARROW  = curses.KEY_DOWN
+    LEFT_ARROW  = curses.KEY_LEFT
+    RIGHT_ARROW = curses.KEY_RIGHT
+    PAGE_UP     = curses.KEY_PPAGE
+    PAGE_DOWN   = curses.KEY_NPAGE
+    F1          = curses.KEY_F1
+    F2          = curses.KEY_F2
+    F3          = curses.KEY_F3
+    F4          = curses.KEY_F4
+    F5          = curses.KEY_F5
+    F6          = curses.KEY_F6
+    F7          = curses.KEY_F7
+    F8          = curses.KEY_F8
+    HOME        = curses.KEY_HOME
+    END         = curses.KEY_END
+    A_LOWER     = get_ascii_from_char('a')
+    B_LOWER     = get_ascii_from_char('b')
+    C_LOWER     = get_ascii_from_char('c')
+    D_LOWER     = get_ascii_from_char('d')
+    E_LOWER     = get_ascii_from_char('e')
+    F_LOWER     = get_ascii_from_char('f')
+    G_LOWER     = get_ascii_from_char('g')
+    H_LOWER     = get_ascii_from_char('h')
+    I_LOWER     = get_ascii_from_char('i')
+    J_LOWER     = get_ascii_from_char('j')
+    K_LOWER     = get_ascii_from_char('k')
+    L_LOWER     = get_ascii_from_char('l')
+    M_LOWER     = get_ascii_from_char('m')
+    N_LOWER     = get_ascii_from_char('n')
+    O_LOWER     = get_ascii_from_char('o')
+    P_LOWER     = get_ascii_from_char('p')
+    Q_LOWER     = get_ascii_from_char('q')
+    R_LOWER     = get_ascii_from_char('r')
+    S_LOWER     = get_ascii_from_char('s')
+    T_LOWER     = get_ascii_from_char('t')
+    U_LOWER     = get_ascii_from_char('u')
+    V_LOWER     = get_ascii_from_char('v')
+    W_LOWER     = get_ascii_from_char('w')
+    X_LOWER     = get_ascii_from_char('x')
+    Y_LOWER     = get_ascii_from_char('y')
+    Z_LOWER     = get_ascii_from_char('z')
+    A_UPPER     = get_ascii_from_char('A')
+    B_UPPER     = get_ascii_from_char('B')
+    C_UPPER     = get_ascii_from_char('C')
+    D_UPPER     = get_ascii_from_char('D')
+    E_UPPER     = get_ascii_from_char('E')
+    F_UPPER     = get_ascii_from_char('F')
+    G_UPPER     = get_ascii_from_char('G')
+    H_UPPER     = get_ascii_from_char('H')
+    I_UPPER     = get_ascii_from_char('I')
+    J_UPPER     = get_ascii_from_char('J')
+    K_UPPER     = get_ascii_from_char('K')
+    L_UPPER     = get_ascii_from_char('L')
+    M_UPPER     = get_ascii_from_char('M')
+    N_UPPER     = get_ascii_from_char('N')
+    O_UPPER     = get_ascii_from_char('O')
+    P_UPPER     = get_ascii_from_char('P')
+    Q_UPPER     = get_ascii_from_char('Q')
+    R_UPPER     = get_ascii_from_char('R')
+    S_UPPER     = get_ascii_from_char('S')
+    T_UPPER     = get_ascii_from_char('T')
+    U_UPPER     = get_ascii_from_char('U')
+    V_UPPER     = get_ascii_from_char('V')
+    W_UPPER     = get_ascii_from_char('W')
+    X_UPPER     = get_ascii_from_char('X')
+    Y_UPPER     = get_ascii_from_char('Y')
+    Z_UPPER     = get_ascii_from_char('Z')
+
+    BACKSPACE   = 8 if platform == 'win32' else curses.KEY_BACKSPACE
+
+
 class KeyMap(object):
     def __init__(self):
         self._bindings = dict()
 
-    def bind_key(self, /, key: Key, *, match: Callable=None, definition: Callable=None, old: Key=None):
+    def bind_key(self, /, key: Key, *, definition: Callable=None, old: Key=None):
         """Binds a key to either a function or a key that previously had a binding
 
         Parameters
@@ -72,10 +154,10 @@ class KeyMap(object):
     def execute(self, key: Key):
         if not isinstance(key, Key):
             raise ValueError(f"{key} is an invalid value for key")
-        elif key not in self._bindings.keys():
-            raise ValueError(f"{key} is an invalid value for key")
+        elif key.value not in self._bindings.keys():
+            return
 
-        self._bindings[key.value]()
+        self._bindings[key.value](key)
 
     def unbind(self, key: Key):
         """Unbinds a key from the map
@@ -87,82 +169,3 @@ class KeyMap(object):
         """
         while key.value in self._bindings:
             del self._bindings[key.value]
-
-class Key(enum.Enum):
-    # Supported py_cui keys
-    KEY_ENTER       = get_ascii_from_char('\n')
-    # Escape character is ascii #27
-    KEY_ESCAPE      = 27
-    KEY_SPACE       = get_ascii_from_char(' ')
-    KEY_DELETE      = curses.KEY_DC
-    KEY_TAB         = get_ascii_from_char('\t')
-    KEY_UP_ARROW    = curses.KEY_UP
-    KEY_DOWN_ARROW  = curses.KEY_DOWN
-    KEY_LEFT_ARROW  = curses.KEY_LEFT
-    KEY_RIGHT_ARROW = curses.KEY_RIGHT
-    KEY_PAGE_UP     = curses.KEY_PPAGE
-    KEY_PAGE_DOWN   = curses.KEY_NPAGE
-    KEY_F1          = curses.KEY_F1
-    KEY_F2          = curses.KEY_F2
-    KEY_F3          = curses.KEY_F3
-    KEY_F4          = curses.KEY_F4
-    KEY_F5          = curses.KEY_F5
-    KEY_F6          = curses.KEY_F6
-    KEY_F7          = curses.KEY_F7
-    KEY_F8          = curses.KEY_F8
-    KEY_HOME        = curses.KEY_HOME
-    KEY_END         = curses.KEY_END
-    KEY_A_LOWER     = get_ascii_from_char('a')
-    KEY_B_LOWER     = get_ascii_from_char('b')
-    KEY_C_LOWER     = get_ascii_from_char('c')
-    KEY_D_LOWER     = get_ascii_from_char('d')
-    KEY_E_LOWER     = get_ascii_from_char('e')
-    KEY_F_LOWER     = get_ascii_from_char('f')
-    KEY_G_LOWER     = get_ascii_from_char('g')
-    KEY_H_LOWER     = get_ascii_from_char('h')
-    KEY_I_LOWER     = get_ascii_from_char('i')
-    KEY_J_LOWER     = get_ascii_from_char('j')
-    KEY_K_LOWER     = get_ascii_from_char('k')
-    KEY_L_LOWER     = get_ascii_from_char('l')
-    KEY_M_LOWER     = get_ascii_from_char('m')
-    KEY_N_LOWER     = get_ascii_from_char('n')
-    KEY_O_LOWER     = get_ascii_from_char('o')
-    KEY_P_LOWER     = get_ascii_from_char('p')
-    KEY_Q_LOWER     = get_ascii_from_char('q')
-    KEY_R_LOWER     = get_ascii_from_char('r')
-    KEY_S_LOWER     = get_ascii_from_char('s')
-    KEY_T_LOWER     = get_ascii_from_char('t')
-    KEY_U_LOWER     = get_ascii_from_char('u')
-    KEY_V_LOWER     = get_ascii_from_char('v')
-    KEY_W_LOWER     = get_ascii_from_char('w')
-    KEY_X_LOWER     = get_ascii_from_char('x')
-    KEY_Y_LOWER     = get_ascii_from_char('y')
-    KEY_Z_LOWER     = get_ascii_from_char('z')
-    KEY_A_UPPER     = get_ascii_from_char('A')
-    KEY_B_UPPER     = get_ascii_from_char('B')
-    KEY_C_UPPER     = get_ascii_from_char('C')
-    KEY_D_UPPER     = get_ascii_from_char('D')
-    KEY_E_UPPER     = get_ascii_from_char('E')
-    KEY_F_UPPER     = get_ascii_from_char('F')
-    KEY_G_UPPER     = get_ascii_from_char('G')
-    KEY_H_UPPER     = get_ascii_from_char('H')
-    KEY_I_UPPER     = get_ascii_from_char('I')
-    KEY_J_UPPER     = get_ascii_from_char('J')
-    KEY_K_UPPER     = get_ascii_from_char('K')
-    KEY_L_UPPER     = get_ascii_from_char('L')
-    KEY_M_UPPER     = get_ascii_from_char('M')
-    KEY_N_UPPER     = get_ascii_from_char('N')
-    KEY_O_UPPER     = get_ascii_from_char('O')
-    KEY_P_UPPER     = get_ascii_from_char('P')
-    KEY_Q_UPPER     = get_ascii_from_char('Q')
-    KEY_R_UPPER     = get_ascii_from_char('R')
-    KEY_S_UPPER     = get_ascii_from_char('S')
-    KEY_T_UPPER     = get_ascii_from_char('T')
-    KEY_U_UPPER     = get_ascii_from_char('U')
-    KEY_V_UPPER     = get_ascii_from_char('V')
-    KEY_W_UPPER     = get_ascii_from_char('W')
-    KEY_X_UPPER     = get_ascii_from_char('X')
-    KEY_Y_UPPER     = get_ascii_from_char('Y')
-    KEY_Z_UPPER     = get_ascii_from_char('Z')
-
-    KEY_BACKSPACE   = 8 if platform == 'win32' else curses.KEY_BACKSPACE

--- a/py_cui/keys.py
+++ b/py_cui/keys.py
@@ -169,3 +169,11 @@ class KeyMap(object):
         """
         while key.value in self._bindings:
             del self._bindings[key.value]
+    
+    def __add__(self, value):
+        if not isinstance(value, self.__class__):
+            raise ValueError(f"Cannot add a KeyMap and {value.__class__} type")
+        else:
+            k = KeyMap()
+            k._bindings = {**value._binings, **self._bindings}
+            return k

--- a/py_cui/keys.py
+++ b/py_cui/keys.py
@@ -42,6 +42,10 @@ def get_char_from_ascii(key_num):
     """
     return chr(key_num)
 
+def ignore_key(method):
+    def wrapper(self, key=None, *args, **kwargs):
+        return method(self)
+    return wrapper
 
 class Key(enum.Enum):
     """Enum representing a Key internally"""

--- a/py_cui/keys.py
+++ b/py_cui/keys.py
@@ -152,13 +152,13 @@ class KeyMap(object):
             The already bound key to bind to
         """
         if not isinstance(key, Key):
-            raise ValueError(f"{key} is an invalid value for key")
+            raise ValueError("{} is an invalid value for key".format(key))
         if old and old.value not in self._bindings:
-            raise ValueError(f"{old} is not in the bindings list, cannot bind to it")
+            raise ValueError("{old} is not in the bindings list, cannot bind to it".format(key))
         if not old and not definition:
-            raise ValueError(f"Either old or definition must be defined")
+            raise ValueError("Either old or definition must be defined".format(key))
         if old and definition:
-            raise ValueError(f"Cannot bind to both a key and a callable")
+            raise ValueError("Cannot bind to both a key and a callable".format(key))
         if old:
             self._bindings[key.value] = self._bindings[old.value]
         else:
@@ -173,7 +173,7 @@ class KeyMap(object):
             The key to execute
         """
         if not isinstance(key, Key):
-            raise ValueError(f"{key} is an invalid value for key")
+            raise ValueError("{} is an invalid value for key".format(key))
         elif key.value not in self._bindings.keys():
             return
 
@@ -192,7 +192,7 @@ class KeyMap(object):
     
     def __add__(self, value):
         if not isinstance(value, self.__class__):
-            raise ValueError(f"Cannot add a KeyMap and {value.__class__} type")
+            raise ValueError("Cannot add a KeyMap and {} type".format(value.__class))
         else:
             k = KeyMap()
             k._bindings = {**value._binings, **self._bindings}

--- a/py_cui/keys.py
+++ b/py_cui/keys.py
@@ -149,7 +149,8 @@ class KeyMap(object):
             raise ValueError(f"Cannot bind to both a key and a callable")
         if old:
             self._bindings[key.value] = self._bindings[old.value]
-        self._bindings[key.value] = definition
+        else:
+            self._bindings[key.value] = (definition, key)
     
     def execute(self, key: Key):
         if not isinstance(key, Key):
@@ -157,7 +158,7 @@ class KeyMap(object):
         elif key.value not in self._bindings.keys():
             return
 
-        self._bindings[key.value](key)
+        self._bindings[key.value][0](self._bindings[key.value][1])
 
     def unbind(self, key: Key):
         """Unbinds a key from the map
@@ -177,3 +178,15 @@ class KeyMap(object):
             k = KeyMap()
             k._bindings = {**value._binings, **self._bindings}
             return k
+
+class RawKeyMap(object):
+    def __init__(self, char_range: range):
+        self.char_range = char_range
+        self.definition = None
+
+    def add_definition(self, definition):
+        self.definition = definition
+
+    def execute(self, key: int):
+        if key in self.char_range and self.definition:
+            self.definition(key)

--- a/py_cui/popups.py
+++ b/py_cui/popups.py
@@ -61,7 +61,7 @@ class Popup:
         self.renderer = renderer
         self.selected = True
         self.key_map = py_cui.keys.KeyMap()
-        self.key_map.bind_key(key=py_cui.keys.Key.ESCAPE, lambda x: self.root.close_popup())
+        self.key_map.bind_key(key=py_cui.keys.Key.ESCAPE, definition=lambda x: self.root.close_popup())
 
     def handle_key_press(self, key_pressed):
         """Handles key presses when popup is open

--- a/py_cui/popups.py
+++ b/py_cui/popups.py
@@ -63,7 +63,7 @@ class Popup:
         self.key_map = py_cui.keys.KeyMap()
         self.key_map.bind_key(key=py_cui.keys.Key.ESCAPE, definition=lambda x: self.root.close_popup())
 
-    def handle_key_press(self, key_pressed):
+    def handle_key_press(self, key_pressed: int):
         """Handles key presses when popup is open
 
         By default, only closes popup when Escape is pressed
@@ -73,7 +73,12 @@ class Popup:
         key_pressed : int
             The ascii code for the key that was pressed
         """
-        self.key_map.execute(key_pressed)
+        try:
+            self.key_map.execute(key_pressed)
+            key = py_cui.keys.Key(key_pressed)
+            self.raw_key_map.execute(key)
+        except ValueError:
+            return
 
     def draw(self):
         """Function that uses renderer to draw the popup
@@ -198,8 +203,7 @@ class TextBoxPopup(Popup):
         self.key_map.bind_key(key=py_cui.keys.Key.HOME, definition=self.jump_to_start)
         self.key_map.bind_key(key=py_cui.keys.Key.END, definition=self.jump_to_end)
         
-        for i in range(32, 128):
-            self.key_map.bind_key(key=py_cui.keys.Key(i), definition=self.insert_char)
+        self.raw_key_map.add_definition(self.insert_char)   
 
     def return_input(self, key: py_cui.keys.Key):
             self.root.close_popup()
@@ -265,7 +269,7 @@ class TextBoxPopup(Popup):
             self.cursor_text_pos = self.cursor_text_pos + 1
 
 
-    def insert_char(self, key: py_cui.keys.Key):
+    def insert_char(self, key: int):
         """Inserts char at cursor position. Internal use only
 
         Parameters

--- a/py_cui/widget_set.py
+++ b/py_cui/widget_set.py
@@ -9,6 +9,7 @@ It can be used to swap between collections of widgets (screens) in a py_cui
 # TODO: Should create an initial widget set in PyCUI class that widgets are added to by default.
 
 import shutil
+import py_cui.keys
 import py_cui.widgets as widgets
 import py_cui.grid as grid
 
@@ -35,7 +36,7 @@ class WidgetSet:
         """
 
         self.widgets = {}
-        self.keybindings = {}
+        self.key_map = py_cui.keys.KeyMap()
         term_size = shutil.get_terminal_size()
 
         self.height = term_size.lines
@@ -68,9 +69,7 @@ class WidgetSet:
         command : Function
             A no-arg or lambda function to fire on keypress
         """
-
-        self.keybindings[key] = command
-
+        self.key_map.bind_key(key=key, definition=lambda x: command())
 
     def add_scroll_menu(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0):
         """Function that adds a new scroll menu to the CUI grid

--- a/py_cui/widget_set.py
+++ b/py_cui/widget_set.py
@@ -63,7 +63,7 @@ class WidgetSet:
 
         Parameters
         ----------
-        key : py_cui.keys.KEY_*
+        key : py_cui.keys.Key.*
             The key bound to the command
         command : Function
             A no-arg or lambda function to fire on keypress

--- a/py_cui/widgets.py
+++ b/py_cui/widgets.py
@@ -102,8 +102,27 @@ class Widget:
         self.raw_key_map = py_cui.keys.RawKeyMap(range(32, 128))
 
     def _on_lose_focus(self, key: py_cui.keys.Key):
+        """Called on this widget losing focus
+
+        Parameters
+        ----------
+        key : Key
+            The key pressed to trigger this event
+        """
         if self.on_lose_focus:
             self.on_lose_focus()
+
+    def add_key_command(self, key, command):
+        """Maps a keycode to a function that will be executed when in focus mode
+
+        Parameters
+        ----------
+        key : py_cui.keys.KEY
+            ascii keycode used to map the key
+        command : function without args
+            a non-argument function or lambda function to execute if in focus mode and key is pressed
+        """
+        self.key_map.bind_key(key=key, definition=lambda x: command())
 
     def set_focus_text(self, text):
         """Function that sets the text of the status bar on focus for a particular widget
@@ -424,14 +443,9 @@ class ScrollMenu(Widget):
         self.top_view = 0
 
 
-    def scroll_up(self, key: py_cui.keys.Key):
-        """Function that scrolls the view up in the scroll menu
-
-        Parameters
-        ----------
-        key : Key
-            The key pressed to trigger this event
-        """
+    @py_cui.keys.ignore_key
+    def scroll_up(self):
+        """Function that scrolls the view up in the scroll menu"""
 
         if self.selected:
             if self.top_view > 0 and self.selected_item == self.top_view:
@@ -440,14 +454,9 @@ class ScrollMenu(Widget):
                 self.selected_item = self.selected_item - 1
 
 
-    def scroll_down(self, key: py_cui.keys.Key):
-        """Function that scrolls the view down in the scroll menu
-
-        Parameters
-        ----------
-        key : Key
-            The key pressed to trigger this event
-        """
+    @py_cui.keys.ignore_key
+    def scroll_down(self):
+        """Function that scrolls the view down in the scroll menu"""
         if self.selected:
             if self.selected_item < len(self.view_items) - 1:
                 self.selected_item = self.selected_item + 1
@@ -559,15 +568,10 @@ class CheckBoxMenu(ScrollMenu):
         self.checked_char = checked_char
         self.set_focus_text('Focus mode on CheckBoxMenu. Use up/down to scroll, Enter to toggle set, unset, Esc to exit.')
         self.key_map.bind(key=py_cui.keys.Key.ENTER, definition=self.select_item)
-        
-    def select_item(self, key: py_cui.keys.Key):
-        """Select a given item and set its view
-
-        Parameters
-        ----------
-        key : Key
-            The key pressed to execute this event
-        """
+    
+    @py_cui.keys.ignore_key
+    def select_item(self):
+        """Select a given item and set its view"""
         if super().get() in self.selected_item_list:
             self.selected_item_list.remove(super().get())
             self.view_items[self.selected_item] = '[ ] - ' + self.view_items[self.selected_item][6:]
@@ -653,14 +657,9 @@ class Button(Widget):
         self.set_focus_text('Focus mode on Button. Press Enter to press button, Esc to exit focus mode.')
         self.key_map.bind_key(key=py_cui.keys.Key.ENTER, definition=self.button_action)
 
-    def button_action(self, key: py_cui.keys.Key):
-        """Called when the button is pressed
-
-        Parameters
-        ----------
-        key : int
-            The key used to trigger this event
-        """
+    @py_cui.keys.ignore_key
+    def button_action(self):
+        """Called when the button is pressed"""
         self.selected_color = py_cui.WHITE_ON_RED
         if self.command is not None:
             ret = self.command()
@@ -775,7 +774,7 @@ class TextBox(Widget):
         self.cursor_text_pos = 0
         self.text = ''
 
-
+    @py_cui.keys.ignore_key
     def move_left(self):
         """Shifts the cursor the the left. Internal use only
         """
@@ -786,6 +785,7 @@ class TextBox(Widget):
             self.cursor_text_pos = self.cursor_text_pos - 1
 
 
+    @py_cui.keys.ignore_key
     def move_right(self):
         """Shifts the cursor the the right. Internal use only
         """
@@ -810,16 +810,16 @@ class TextBox(Widget):
             self.cursor_x = self.cursor_x + 1
         self.cursor_text_pos = self.cursor_text_pos + 1
 
-
-    def jump_to_start(self, key: py_cui.keys.Key):
+    @py_cui.keys.ignore_key
+    def jump_to_start(self):
         """Jumps to the start of the textbox
         """
 
         self.cursor_x = self.start_x + self.padx + 2
         self.cursor_text_pos = 0
 
-
-    def jump_to_end(self, key: py_cui.keys.Key):
+    @py_cui.keys.ignore_key
+    def jump_to_end(self):
         """Jumps to the end to the textbox
         """
 
@@ -827,7 +827,8 @@ class TextBox(Widget):
         self.cursor_x = self.start_x + self.padx + 2 + self.cursor_text_pos
 
 
-    def erase_char(self, key: py_cui.keys.Key):
+    @py_cui.keys.ignore_key
+    def erase_char(self):
         """Erases character at textbox cursor
         """
 
@@ -837,7 +838,8 @@ class TextBox(Widget):
                 self.cursor_x = self.cursor_x - 1
             self.cursor_text_pos = self.cursor_text_pos - 1
 
-    def delete_char(self, key: py_cui.keys.Key):
+    @py_cui.keys.ignore_key
+    def delete_char(self):
         """Deletes character to right of texbox cursor
         """
 
@@ -918,7 +920,7 @@ class ScrollTextBlock(Widget):
         self.key_map.bind_key(key=py_cui.keys.Key.BACKSPACE, definition=self.handle_backspace)
         self.key_map.bind_key(key=py_cui.keys.Key.DELETE, definition=self.handle_delete)
         self.key_map.bind_key(key=py_cui.keys.Key.ENTER, definition=self.handle_newline)
-        self.key_map.bind_key(key=py_cui.keys.Key.TAB, definition=lambda x: [self.insert_char(py_cui.keys.Key.SPACE) for _ in range(4)])
+        self.key_map.bind_key(key=py_cui.keys.Key.TAB, definition=lambda x: [self.insert_char(py_cui.keys.Key.SPACE.value) for _ in range(4)])
         self.key_map.bind_key(key=py_cui.keys.Key.HOME, definition=self.handle_home)
         self.key_map.bind_key(key=py_cui.keys.Key.END, definition=self.handle_end)
         
@@ -1032,7 +1034,8 @@ class ScrollTextBlock(Widget):
         self.text_lines[self.cursor_text_pos_y] = text
 
 
-    def move_left(self, key: py_cui.keys.Key):
+    @py_cui.keys.ignore_key
+    def move_left(self):
         """Function that moves the cursor/text position one location to the left
         """
         if self.cursor_text_pos_x > 0:
@@ -1043,7 +1046,8 @@ class ScrollTextBlock(Widget):
             self.cursor_text_pos_x = self.cursor_text_pos_x - 1
 
 
-    def move_right(self, key: py_cui.keys.Key):
+    @py_cui.keys.ignore_key
+    def move_right(self):
         """Function that moves the cursor/text position one location to the right
         """
 
@@ -1057,7 +1061,8 @@ class ScrollTextBlock(Widget):
             self.cursor_text_pos_x = self.cursor_text_pos_x + 1
 
 
-    def move_up(self, key: py_cui.keys.Key):
+    @py_cui.keys.ignore_key
+    def move_up(self):
         """Function that moves the cursor/text position one location up
         """
 
@@ -1073,7 +1078,8 @@ class ScrollTextBlock(Widget):
                 self.cursor_text_pos_x = temp
 
 
-    def move_down(self, key: py_cui.keys.Key):
+    @py_cui.keys.ignore_key
+    def move_down(self):
         """Function that moves the cursor/text position one location down
         """
         if self.cursor_text_pos_y < len(self.text_lines) - 1:
@@ -1088,7 +1094,8 @@ class ScrollTextBlock(Widget):
                 self.cursor_text_pos_x = temp
 
 
-    def handle_newline(self, key: py_cui.keys.Key):
+    @py_cui.keys.ignore_key
+    def handle_newline(self):
         """Function that handles recieving newline characters in the text
         """
 
@@ -1108,7 +1115,8 @@ class ScrollTextBlock(Widget):
             self.viewport_y_start = self.viewport_y_start + 1
 
 
-    def handle_backspace(self, key: py_cui.keys.Key):
+    @py_cui.keys.ignore_key
+    def handle_backspace(self):
         """Function that handles recieving backspace characters in the text
         """
 
@@ -1130,8 +1138,8 @@ class ScrollTextBlock(Widget):
                 self.cursor_x = self.cursor_x - 1
             self.cursor_text_pos_x = self.cursor_text_pos_x - 1
 
-
-    def handle_home(self, key: py_cui.keys.Key):
+    @py_cui.keys.ignore_key
+    def handle_home(self):
         """Function that handles recieving a home keypress
         """
 
@@ -1140,7 +1148,8 @@ class ScrollTextBlock(Widget):
         self.viewport_x_start = 0
 
 
-    def handle_end(self, key: py_cui.keys.Key):
+    @py_cui.keys.ignore_key
+    def handle_end(self):
         """Function that handles recieving an end keypress
         """
 
@@ -1154,7 +1163,8 @@ class ScrollTextBlock(Widget):
             self.cursor_x = self.cursor_max_left + len(current_line)
 
 
-    def handle_delete(self, key: py_cui.keys.Key):
+    @py_cui.keys.ignore_key
+    def handle_delete(self):
         """Function that handles recieving a delete keypress
         """
 
@@ -1178,7 +1188,7 @@ class ScrollTextBlock(Widget):
 
         current_line = self.get_current_line()
 
-        self.set_text_line(current_line[:self.cursor_text_pos_x] + chr(key_pressed) + current_line[self.cursor_text_pos_x:])
+        self.set_text_line(current_line[:self.cursor_text_pos_x] + chr(key) + current_line[self.cursor_text_pos_x:])
         if len(current_line) <= self.width - 2 * self.padx - 4:
             self.cursor_x = self.cursor_x + 1
         elif self.viewport_x_start + self.width - 2 * self.padx - 4 < len(current_line):

--- a/tests/test_text_block.py
+++ b/tests/test_text_block.py
@@ -44,7 +44,7 @@ def test_get_initial():
 
 def test_insert_char():
     text_box = py_cui.widgets.ScrollTextBlock('id', 'Test', grid_test, 1, 1, 1, 2, 1, 0 , 'Hello World')
-    text_box.insert_char(py_cui.keys.KEY_D_UPPER)
+    text_box.insert_char(py_cui.keys.Key.D_UPPER.value)
     assert text_box.get_current_line() == 'DHello World'
     assert text_box.cursor_x == text_box.cursor_max_left + 1
     assert text_box.cursor_text_pos_x == 1
@@ -74,8 +74,8 @@ def test_get_edited():
     for i in range(0, 3):
         text_box.move_right()
     text_box.handle_backspace()
-    text_box.insert_char(py_cui.keys.KEY_A_LOWER)
-    text_box.insert_char(py_cui.keys.KEY_E_UPPER)
+    text_box.insert_char(py_cui.keys.Key.A_LOWER.value)
+    text_box.insert_char(py_cui.keys.Key.E_UPPER.value)
     assert text_box.cursor_x == text_box.cursor_max_left + 4
     assert text_box.cursor_text_pos_x == 4
     assert text_box.get_current_line() == 'HeaElo World'

--- a/tests/test_text_box.py
+++ b/tests/test_text_box.py
@@ -40,7 +40,7 @@ def test_get_initial():
 
 def test_insert_char():
     text_box = py_cui.widgets.TextBox('id', 'Test', grid_test, 1, 1, 1, 2, 1, 0 , 'Hello World', False)
-    text_box.insert_char(py_cui.keys.KEY_D_UPPER)
+    text_box.insert_char(py_cui.keys.Key.D_UPPER.value)
     assert text_box.get() == 'DHello World'
     assert text_box.cursor_x == text_box.cursor_max_left + 1
     assert text_box.cursor_text_pos == 1
@@ -61,8 +61,8 @@ def test_get_edited():
     for i in range(0, 3):
         text_box.move_right()
     text_box.erase_char()
-    text_box.insert_char(py_cui.keys.KEY_A_LOWER)
-    text_box.insert_char(py_cui.keys.KEY_E_UPPER)
+    text_box.insert_char(py_cui.keys.Key.A_LOWER.value)
+    text_box.insert_char(py_cui.keys.Key.E_UPPER.value)
     assert text_box.cursor_x == text_box.cursor_max_left + 4
     assert text_box.cursor_text_pos == 4
     assert text_box.get() == 'HeaElo World'


### PR DESCRIPTION
In the name of moving toward a more event driven interface, and having greater customization I have added KeyMaps.

### Why
The basic theory is that each mapped key corresponds either to a method/function, or to another mapped key which then corresponds to a method. The original intent was twofold, to make declaring new keybindings simpler/to cleanup the handle_key_press methods, as well as making it easier to have multiple binds for the same action. I wanted to include some vim-like movement in my TUI, Now this can be done simply with four lines of code, an if you were to make a KeyMap and store it in a config file it could be used in multiple different programs.

### Changes
The biggest change is the introduction of the KeyMap class, which provides the main functionality for the new mapping. Every widget/popup has a key_map which it inherits from the base Widget/Popup class. The children can then simply add their bindings to the parent key_map and when the parent goes to handle a key_press it will automatically consider the children's bindings.

### Considerations
I have not fully finished implementing this feature yet, I will need to write a few docstrings and upate tests/examples to reflect the new api. I also feel like the scope of the change would warrant a MINOR version increment to 0.2.0 rather than PATCH

Let me know what you think, I have a few ideas about using decorators to perform the same duty as the KeyMap.bind_key method currently does. This would increase the event driven nature and reduce some excess code.

I have made an updated verision of the todo-list example with the new key binding method and the vim controls [here](https://gist.github.com/telday/227d39502d2fe017deb8b8b3c3b007f9)