### PR TITLE
WIP: Add a focus border color

### DIFF
--- a/py_cui/ui.py
+++ b/py_cui/ui.py
@@ -37,6 +37,10 @@ class UIElement:
         absolute dimensions of ui element in terminal characters
     _color : int
         Default color for which to draw element
+    _border_color: int
+        Color used to draw the border of the element when not focused
+    _focus_border_color: int
+        Color used to draw the border of the element when focused
     _selected : bool
         toggle for marking an element as selected
     _renderer : py_cui.renderer.Renderer
@@ -60,6 +64,7 @@ class UIElement:
         self._height,   self._width     = 0, 0
         self._color                     = py_cui.WHITE_ON_BLACK
         self._border_color              = self._color
+        self._focus_border_color        = self._color
         self._selected_color            = self._color
         self._mouse_press_handler       = None
         self._selected                  = False
@@ -199,7 +204,10 @@ class UIElement:
             color code for combination
         """
 
-        return self._border_color
+        if self._selected:
+            return self._focus_border_color
+        else:
+            return self._border_color
 
 
     def get_selected_color(self):
@@ -289,6 +297,17 @@ class UIElement:
 
         self._border_color = color
 
+    def set_focus_border_color(self, color):
+        """Sets element border color if the current element
+        is focused
+
+        Parameters
+        ----------
+        color : int
+            New color pair key code
+        """
+
+        self._focus_border_color = color
 
     def set_selected_color(self, color):
         """Sets element sected color


### PR DESCRIPTION
Quick summary of pull request...

- [x] I have read the contribution guidelines
- [x] CI Unit tests pass
- [x] New functions/classes have consistent docstrings

**What this pull request changes**

* Add attribute `_focus_border_color` to store the border color of a `UIElement` when element is focused/selected
* Add setter method for `_focus_border_color`
* Update `get_border_color` to return `_focus_border_color` if `_selected` is true, else return `_border_color`

#### TODO
* Update docs
* Test more UIElements other than scroll menus

-----

Examples:

```python
import py_cui

class SimpleTodoList:

    def __init__(self, master):

        self.master = master

        # The scrolled list cells that will contain our tasks in each of the three categories
        self.todo_scroll_cell = self.master.add_scroll_menu('TODO', 0, 0, row_span=6, column_span=2)
        self.todo_scroll_cell.set_focus_border_color(py_cui.GREEN_ON_BLACK)

        self.in_progress_scroll_cell = self.master.add_scroll_menu('In Progress', 0, 2, row_span=7, column_span=2)
        self.done_scroll_cell = self.master.add_scroll_menu('Done', 0, 4, row_span=7, column_span=2)

        # Textbox for entering new items
        self.new_todo_textbox = self.master.add_text_box('TODO Item', 6, 0, column_span=2)

# Create the CUI with 7 rows 6 columns, pass it to the wrapper object, and start it
root = py_cui.PyCUI(7, 6)

# If we want to use unicode box characters, we toggle them on here.
root.toggle_unicode_borders()
root.set_title('CUI TODO List')
s = SimpleTodoList(root)
root.start()
```

<img width="1142" alt="Screen Shot 2020-10-10 at 8 03 52 PM" src="https://user-images.githubusercontent.com/13981456/95668179-f36b4d80-0b35-11eb-9825-44f604a3ef91.png">

