### PR TITLE
Add annotations to widget adding functions

### DIFF
--- a/examples/autogit.py
+++ b/examples/autogit.py
@@ -18,7 +18,7 @@ __version__ = '0.0.1'
 
 class AutoGitCUI:
 
-    def __init__(self, root, dir):
+    def __init__(self, root: py_cui.PyCUI, dir):
         self.root = root
         self.dir = dir
         os.chdir(self.dir)

--- a/examples/control_widgets/slider.py
+++ b/examples/control_widgets/slider.py
@@ -4,7 +4,7 @@ import py_cui
 
 
 class App:
-    def __init__(self, master):
+    def __init__(self, master: py_cui.PyCUI):
         self.master = master
 
         self.g1 = self.master.add_scroll_menu('GRID1',
@@ -18,7 +18,7 @@ class App:
         self.g4.set_slider_step(3)
 
 
-root = py_cui.PyCUI(9,6)
+root = py_cui.PyCUI(9, 6)
 root.set_title('Test Slider')
 s = App(root)
 root.start()

--- a/examples/dialog_widgets/form_demo.py
+++ b/examples/dialog_widgets/form_demo.py
@@ -3,7 +3,7 @@ import logging
 
 class App:
 
-    def __init__(self, master):
+    def __init__(self, master: py_cui.PyCUI):
 
         # Variable that will store user inputs from form
         self.form_results = None

--- a/examples/hello_py_cui.py
+++ b/examples/hello_py_cui.py
@@ -9,7 +9,7 @@ The most basic possible use case for py_cui
 import py_cui
 
 # create the CUI object. Will have a 3 by 3 grid with indexes from 0,0 to 2,2
-root = py_cui.PyCUI(3,3)
+root = py_cui.PyCUI(3, 3)
 
 # Add a label to the center of the CUI in the 1,1 grid position
 root.add_label('Hello py_cui!!!', 1, 1)

--- a/examples/multi_window_demo.py
+++ b/examples/multi_window_demo.py
@@ -9,7 +9,7 @@ import py_cui
 
 class MultiWindowDemo:
 
-    def __init__(self, root):
+    def __init__(self, root: py_cui.PyCUI):
 
         # Root PyCUI window
         self.root = root

--- a/examples/popups_example.py
+++ b/examples/popups_example.py
@@ -12,7 +12,7 @@ import logging
 
 class PopupExample:
 
-    def __init__(self, master):
+    def __init__(self, master: py_cui.PyCUI):
 
         # This is a reference to our top level CUI object
         self.master = master

--- a/examples/simple_todo_list.py
+++ b/examples/simple_todo_list.py
@@ -10,7 +10,7 @@ import logging
 
 class SimpleTodoList:
 
-    def __init__(self, master):
+    def __init__(self, master: py_cui.PyCUI):
 
         self.master = master
 

--- a/examples/snano.py
+++ b/examples/snano.py
@@ -17,7 +17,7 @@ __version__ = '0.0.1'
 
 class SuperNano:
 
-    def __init__(self, root, dir):
+    def __init__(self, root: py_cui.PyCUI, dir):
 
         # Wrapper class takes its parent PyCUI object
         self.root = root

--- a/py_cui/__init__.py
+++ b/py_cui/__init__.py
@@ -443,7 +443,7 @@ class PyCUI:
     # Widget add functions. Each of these adds a particular type of widget
     # to the grid in a specified location.
 
-    def add_scroll_menu(self, title, row, column, row_span=1, column_span=1, padx=1, pady=0):
+    def add_scroll_menu(self, title, row, column, row_span=1, column_span=1, padx=1, pady=0) -> py_cui.widgets.ScrollMenu:
         """Function that adds a new scroll menu to the CUI grid
 
         Parameters
@@ -487,7 +487,7 @@ class PyCUI:
         return new_scroll_menu
 
 
-    def add_checkbox_menu(self, title, row, column, row_span=1, column_span=1, padx=1, pady=0, checked_char='X'):
+    def add_checkbox_menu(self, title, row, column, row_span=1, column_span=1, padx=1, pady=0, checked_char='X') -> py_cui.widgets.CheckBoxMenu:
         """Function that adds a new checkbox menu to the CUI grid
 
         Parameters
@@ -534,7 +534,7 @@ class PyCUI:
         return new_checkbox_menu
 
 
-    def add_text_box(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0, initial_text = '', password = False):
+    def add_text_box(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0, initial_text = '', password = False) -> py_cui.widgets.TextBox:
         """Function that adds a new text box to the CUI grid
 
         Parameters
@@ -582,7 +582,7 @@ class PyCUI:
         return new_text_box
 
 
-    def add_text_block(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0, initial_text = ''):
+    def add_text_block(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0, initial_text = '') -> py_cui.widgets.ScrollTextBlock:
         """Function that adds a new text block to the CUI grid
 
         Parameters
@@ -629,7 +629,7 @@ class PyCUI:
         return new_text_block
 
 
-    def add_label(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0):
+    def add_label(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0) -> py_cui.widgets.Label:
         """Function that adds a new label to the CUI grid
 
         Parameters
@@ -671,7 +671,7 @@ class PyCUI:
         return new_label
 
 
-    def add_block_label(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0, center=True):
+    def add_block_label(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0, center=True) -> py_cui.widgets.BlockLabel:
         """Function that adds a new block label to the CUI grid
 
         Parameters
@@ -716,7 +716,7 @@ class PyCUI:
         return new_label
 
 
-    def add_button(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0, command=None):
+    def add_button(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0, command=None) -> py_cui.widgets.Button:
         """Function that adds a new button to the CUI grid
 
         Parameters
@@ -764,7 +764,7 @@ class PyCUI:
 
     def add_slider(self, title, row, column, row_span=1,
                    column_span=1, padx=1, pady=0,
-                   min_val=0, max_val=100, step=1, init_val=0):
+                   min_val=0, max_val=100, step=1, init_val=0) -> py_cui.control_widgets.slider:
         """Function that adds a new label to the CUI grid
 
         Parameters


### PR DESCRIPTION
A really minor changes, only 8 lines are affected.

---

- [x] I have read the contribution guidelines
- [x] CI Unit tests pass
- [x] New functions/classes have consistent docstrings

---

**What this pull request changes**

* Adds [annotations](https://www.python.org/dev/peps/pep-3107/) to *add_{widget}* functions.

---

**Issues fixed with this pull request**

By just adding few annotations, this will allow IDEs extensive features such as suggestions, debugging, etc. - Which helps newcomers adapting to module's APIs, as some entries of [Official docs](https://jwlodek.github.io/py_cui-docs/) is not covering full features yet. 


![image](https://user-images.githubusercontent.com/26041217/104034579-69a24d80-5214-11eb-8dde-411099d38e45.png)
![image](https://user-images.githubusercontent.com/26041217/104034614-77f06980-5214-11eb-91f7-0483e641e7e9.png)

Still, one need to put annotations on their class initializer to work this way.
```
class AudioPlayer:
    def __init__(self, root: py_cui.PyCUI):
        self.root_ = root
```