### PR TITLE
Fixed small issue in popups example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -166,7 +166,7 @@ class PopupExample:
             color = py_cui.CYAN_ON_BLACK
         elif new_color == "MAGENTA":
             color = py_cui.MAGENTA_ON_BLACK
-        for key in self.master.widgets.keys():
+        for key in self.master.get_widgets().keys():
             if isinstance(self.master.get_widgets()[key], py_cui.widgets.Button):
                 self.master.get_widgets()[key].set_color(color)
 


### PR DESCRIPTION
The change_button_color method tried to iterate over self.master.widgets, which is not defined. Changed to self.master.get_widgets() which seems to be the intended behaviour.

Quick summary of pull request...

- [X] I have read the contribution guidelines
- [ ] CI Unit tests pass
- [ ] New functions/classes have consistent docstrings

**What this pull request changes**

Tiny bugfix to example code.

**Issues fixed with this pull request**

  File "popups.py", line 76, in change_button_color
    for key in self.master.widgets.keys():
AttributeError: 'PyCUI' object has no attribute 'widgets'

**Optionally, what changes should join this PR**

* Change Docs
...
