### PR TITLE
Fix on button crashing when initialized without designated command.

### DIFF
--- a/py_cui/__init__.py
+++ b/py_cui/__init__.py
@@ -1035,8 +1035,11 @@ class PyCUI:
         self.set_selected_widget(widget.get_id())
         # If autofocus buttons is selected, we automatically process the button command and reset to overview mode
         if self._auto_focus_buttons and auto_press_buttons and isinstance(widget, py_cui.widgets.Button):
-            widget.command()
+            if widget.command is not None:
+                widget.command()
+
             self._logger.info('Moved focus to button {} - ran autofocus command'.format(widget.get_title()))
+
         elif self._auto_focus_buttons and isinstance(widget, py_cui.widgets.Button):
             self.status_bar.set_text(self._init_status_bar_text)
         else:

--- a/py_cui/widgets.py
+++ b/py_cui/widgets.py
@@ -607,8 +607,7 @@ class Button(Widget):
         super()._handle_key_press(key_pressed)
         if key_pressed == py_cui.keys.KEY_ENTER:
             if self.command is not None:
-                ret = self.command()
-            return ret
+                return self.command()
 
 
     def _draw(self):


### PR DESCRIPTION
Quick summary of pull request...

- [x] I have read the contribution guidelines
- [x] CI Unit tests pass

**What this pull request changes**

* Additional check on button widget

**Issues fixed with this pull request**

* Fixes Button Widget crashing when leaving command to use it's default parameter ```None```.

**Optionally, what changes should join this PR**

* None

---

Very minor PR for #86

As you're seems to be having a busy days, I'll use this chance to address multiple minor issues in this PR, if you allow me to do so. That way you don't have to check and merge multiple small PR at cost of your precious free time.

Additional issues I'd like to address/include as follows:

1. Wrong type annotation ```function```
    https://github.com/jwlodek/py_cui/blob/5f436db763829fd8f01529db1433baac7f8b375f/py_cui/__init__.py#L196-L203
    It need to be `Callable` not `function`, this will cause IDE to complain about wrong parameter type, as there is [no such built-in type](https://stackoverflow.com/questions/41942661/function-is-an-object-of-class-in-python) called *function* in python, despite it's name can be seen with ```type(<function_name>)```.

2.  Relieving type restraint on ```PyCUI.set_refresh_timeout```
    https://github.com/jwlodek/py_cui/blob/5f436db763829fd8f01529db1433baac7f8b375f/py_cui/__init__.py#L183-L193
    Passing *float* such as *0.3* works nicely and can be utilized in interesting way such as updating real-time data. Using ```float``` or ```Union[int, float]``` would work nicely.

I'll update with additional commits for these if you're good with those.
