### PR TITLE
Fix issue with renderer not being assigned to widgets 

### DIFF
--- a/py_cui/__init__.py
+++ b/py_cui/__init__.py
@@ -470,16 +470,17 @@ class PyCUI:
         """
 
         id = 'Widget{}'.format(len(self._widgets.keys()))
-        new_scroll_menu     = py_cui.widgets.ScrollMenu(id,
-                                                 title,
-                                                 self._grid,
-                                                 row,
-                                                 column,
-                                                 row_span,
-                                                 column_span,
-                                                 padx,
-                                                 pady,
-                                                 self._logger)
+        new_scroll_menu = py_cui.widgets.ScrollMenu(id,
+                                                    title,
+                                                    self._grid,
+                                                    row,
+                                                    column,
+                                                    row_span,
+                                                    column_span,
+                                                    padx,
+                                                    pady,
+                                                    self._logger)
+        new_scroll_menu._assign_renderer(self._renderer)
         self._widgets[id]  = new_scroll_menu
         if self._selected_widget is None:
             self.set_selected_widget(id)
@@ -516,17 +517,18 @@ class PyCUI:
         """
 
         id = 'Widget{}'.format(len(self._widgets.keys()))
-        new_checkbox_menu   = py_cui.widgets.CheckBoxMenu(id,
-                                                   title,
-                                                   self._grid,
-                                                   row,
-                                                   column,
-                                                   row_span,
-                                                   column_span,
-                                                   padx,
-                                                   pady,
-                                                   self._logger,
-                                                   checked_char)
+        new_checkbox_menu = py_cui.widgets.CheckBoxMenu(id,
+                                                        title,
+                                                        self._grid,
+                                                        row,
+                                                        column,
+                                                        row_span,
+                                                        column_span,
+                                                        padx,
+                                                        pady,
+                                                        self._logger,
+                                                        checked_char)
+        new_checkbox_menu._assign_renderer(self._renderer)
         self._widgets[id]  = new_checkbox_menu
         if self._selected_widget is None:
             self.set_selected_widget(id)
@@ -565,7 +567,7 @@ class PyCUI:
         """
 
         id = 'Widget{}'.format(len(self._widgets.keys()))
-        new_text_box        = py_cui.widgets.TextBox(id,
+        new_text_box = py_cui.widgets.TextBox(id,
                                               title,
                                               self._grid,
                                               row, column,
@@ -575,6 +577,7 @@ class PyCUI:
                                               self._logger,
                                               initial_text,
                                               password)
+        new_text_box._assign_renderer(self._renderer)
         self._widgets[id]    = new_text_box
         if self._selected_widget is None:
             self.set_selected_widget(id)
@@ -611,17 +614,18 @@ class PyCUI:
         """
 
         id = 'Widget{}'.format(len(self._widgets.keys()))
-        new_text_block      = py_cui.widgets.ScrollTextBlock(id,
-                                                      title,
-                                                      self._grid,
-                                                      row,
-                                                      column,
-                                                      row_span,
-                                                      column_span,
-                                                      padx,
-                                                      pady,
-                                                      self._logger,
-                                                      initial_text)
+        new_text_block = py_cui.widgets.ScrollTextBlock(id,
+                                                        title,
+                                                        self._grid,
+                                                        row,
+                                                        column,
+                                                        row_span,
+                                                        column_span,
+                                                        padx,
+                                                        pady,
+                                                        self._logger,
+                                                        initial_text)
+        new_text_block._assign_renderer(self._renderer)
         self._widgets[id]  = new_text_block
         if self._selected_widget is None:
             self.set_selected_widget(id)
@@ -656,16 +660,17 @@ class PyCUI:
         """
 
         id = 'Widget{}'.format(len(self._widgets.keys()))
-        new_label           = py_cui.widgets.Label(id,
-                                            title,
-                                            self._grid,
-                                            row,
-                                            column,
-                                            row_span,
-                                            column_span,
-                                            padx,
-                                            pady,
-                                            self._logger)
+        new_label = py_cui.widgets.Label(id,
+                                         title,
+                                         self._grid,
+                                         row,
+                                         column,
+                                         row_span,
+                                         column_span,
+                                         padx,
+                                         pady,
+                                         self._logger)
+        new_label._assign_renderer(self._renderer)
         self._widgets[id]  = new_label
         self._logger.info('Adding widget {} w/ ID {} of type {}'.format(title, id, str(type(new_label))))
         return new_label
@@ -700,17 +705,18 @@ class PyCUI:
         """
 
         id = 'Widget{}'.format(len(self._widgets.keys()))
-        new_label           = py_cui.widgets.BlockLabel(id,
-                                                 title,
-                                                 self._grid,
-                                                 row,
-                                                 column,
-                                                 row_span,
-                                                 column_span,
-                                                 padx,
-                                                 pady,
-                                                 center,
-                                                 self._logger)
+        new_label = py_cui.widgets.BlockLabel(id,
+                                              title,
+                                              self._grid,
+                                              row,
+                                              column,
+                                              row_span,
+                                              column_span,
+                                              padx,
+                                              pady,
+                                              center,
+                                              self._logger)
+        new_label._assign_renderer(self._renderer)
         self._widgets[id]  = new_label
         self._logger.info('Adding widget {} w/ ID {} of type {}'.format(title, id, str(type(new_label))))
         return new_label
@@ -745,17 +751,18 @@ class PyCUI:
         """
 
         id = 'Widget{}'.format(len(self._widgets.keys()))
-        new_button          = py_cui.widgets.Button(id,
-                                             title,
-                                             self._grid,
-                                             row,
-                                             column,
-                                             row_span,
-                                             column_span,
-                                             padx,
-                                             pady,
-                                             self._logger,
-                                             command)
+        new_button = py_cui.widgets.Button(id,
+                                           title,
+                                           self._grid,
+                                           row,
+                                           column,
+                                           row_span,
+                                           column_span,
+                                           padx,
+                                           pady,
+                                           self._logger,
+                                           command)
+        new_button._assign_renderer(self._renderer)
         self._widgets[id]  = new_button
         if self._selected_widget is None:
             self.set_selected_widget(id)
@@ -814,12 +821,13 @@ class PyCUI:
                                                          max_val,
                                                          step,
                                                          init_val)
+        new_slider._assign_renderer(self._renderer)
         self._widgets[id] = new_slider
         self._logger.info('Adding widget {} w/ ID {} of type {}'
                            .format(title, id, str(type(new_slider))))
         return new_slider
 
-    
+
     def get_element_at_position(self, x, y):
         """Returns containing widget for character position
 

--- a/py_cui/ui.py
+++ b/py_cui/ui.py
@@ -401,7 +401,7 @@ class UIElement:
         raise NotImplementedError
 
 
-    def _assign_renderer(self, renderer):
+    def _assign_renderer(self, renderer, quiet=False):
         """Function that assigns a renderer object to the element
 
         (Meant for internal usage only)
@@ -417,10 +417,12 @@ class UIElement:
             If parameter is not an initialized renderer.
         """
 
-        if isinstance(renderer, py_cui.renderer.Renderer):
-            self._renderer = renderer
+        if renderer is None:
+            self._logger.debug('Renderer to assign is a NoneType')
         elif self._renderer is not None:
             raise py_cui.errors.PyCUIError('Renderer already assigned for the element')
+        elif isinstance(renderer, py_cui.renderer.Renderer):
+            self._renderer = renderer
         else:
             raise py_cui.errors.PyCUIError('Invalid renderer, must be of type py_cui.renderer.Renderer')
 

--- a/py_cui/widgets.py
+++ b/py_cui/widgets.py
@@ -450,7 +450,6 @@ class ScrollMenu(Widget, py_cui.ui.MenuImplementation):
             self._jump_down(viewport_height)
 
 
-
     def _draw(self):
         """Overrides base class draw function
         """


### PR DESCRIPTION
When widget was added after UI was started, the widget renderer was not assigned correctly, which would cause UI application to crash on the next draw call.

Quick summary of pull request...

- [X] I have read the contribution guidelines
- [X] CI Unit tests pass
- [X] New functions/classes have consistent docstrings

**What this pull request changes**

* Add a call to `_assign_renderer` in all the add widget functions
* Add additional condition to `_assign_renderer` to handle widgets that are added before Renderer is created

**Issues fixed with this pull request**

* https://github.com/jwlodek/py_cui/issues/106
* https://github.com/jwlodek/py_cui/issues/28
