### PR TITLE
V0.1.4 develop

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -86,7 +86,7 @@ class MenuImplementation(UIImplementation):
         if self._selected_item > 0:
             self._selected_item = self._selected_item - 1
 
-        self._logger.debug('Scrolling up to item {}'.format(self._selected_item))
+        self._logger.debug(f'Scrolling up to item {self._selected_item}'))
 
     def _scroll_down(self, viewport_height):
         if self._selected_item < len(self._view_items) - 1:
@@ -94,22 +94,22 @@ class MenuImplementation(UIImplementation):
         if self._selected_item > self._top_view + viewport_height:
             self._top_view = self._top_view + 1
 
-        self._logger.debug('Scrolling down to item {}'.format(self._selected_item))
+        self._logger.debug(f'Scrolling down to item {self._selected_item}')
 
     def add_item(self, item_text):
-        self._logger.debug('Adding item {} to menu'.format(item_text))
+        self._logger.debug(f'Adding item {item_text} to menu')
         self._view_items.append(item_text)
 
 
     def add_item_list(self, item_list):
-        self._logger.debug('Adding item list {} to menu'.format(str(item_list)))
+        self._logger.debug(f'Adding item list {str(item_list)} to menu')
         for item in item_list:
             self.add_item(item)
 
     def remove_selected_item(self):
         if len(self._view_items) == 0:
             return
-        self._logger.debug('Removing {}'.format(self._view_items[self._selected_item]))
+        self._logger.debug(f'Removing {self._view_items[self._selected_item]}')
         del self._view_items[self._selected_item]
         if self._selected_item >= len(self._view_items):
             self._selected_item = self._selected_item - 1
@@ -205,7 +205,7 @@ Finally, add a function to the `PyCUI` class in `__init__.py` that will add the 
 ```Python
 def add_scroll_menu(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0):
 
-    id = 'Widget{}'.format(len(self.get_widgets().keys()))
+    id = f'Widget{len(self.get_widgets().keys())}'
     new_scroll_menu = widgets.ScrollMenu(   id, 
                                             title, 
                                             self._grid, 
@@ -219,7 +219,7 @@ def add_scroll_menu(self, title, row, column, row_span = 1, column_span = 1, pad
     self.get_widgets()[id] = new_scroll_menu
     if self._selected_widget is None:
         self.set_selected_widget(id)
-    self._logger.debug('Adding widget {} w/ ID {} of type {}'.format(title, id, str(type(new_scroll_menu))))
+    self._logger.debug(f'Adding widget {title} w/ ID {id} of type {str(type(new_scroll_menu))}')
     return new_scroll_menu
 ```
 The function must:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -51,7 +51,7 @@ class SimpleTodoList:
     def add_item(self):
         """ Add a todo item """
 
-        self.todo_scroll_cell.add_item('{}'.format(self.new_todo_textbox.get()))
+        self.todo_scroll_cell.add_item(f'{self.new_todo_textbox.get()}')
         self.new_todo_textbox.clear()
 
     def mark_as_in_progress(self):

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -128,7 +128,7 @@ class SimpleTodoList:
     def add_item(self):
         """ Add a todo item """
 
-        self.todo_scroll_cell.add_item('{}'.format(self.new_todo_textbox.get()))
+        self.todo_scroll_cell.add_item(f'{self.new_todo_textbox.get()}')
         self.new_todo_textbox.clear()
 
 

--- a/examples/autogit.py
+++ b/examples/autogit.py
@@ -13,12 +13,10 @@ import getpass
 from subprocess import Popen, PIPE
 
 
-__version__ = '0.0.1'
+__version__ = "0.0.1"
 
 
 class AutoGitCUI:
-
-
     def __init__(self, root: py_cui.PyCUI, dir):
         self.root = root
 
@@ -27,17 +25,17 @@ class AutoGitCUI:
         os.chdir(self.dir)
 
         # get current git status
-        proc = Popen(['git', 'status', '-s'], stdout=PIPE, stderr=PIPE)
+        proc = Popen(["git", "status", "-s"], stdout=PIPE, stderr=PIPE)
         while proc.returncode is None:
             proc.wait()
         res = proc.returncode
         if res != 0:
             print(res)
-            print('ERROR - fatal, {} is not a git repository.'.format(self.dir))
+            print(f"ERROR - fatal, {self.dir} is not a git repository.")
             exit()
 
         # Set title
-        self.root.set_title('Autogit v{} - {}'.format(__version__, os.path.basename(self.dir)))
+        self.root.set_title(f"Autogit v{__version__} - {os.path.basename(self.dir)}")
 
         # Keybindings when in overview mode, and set info bar
         self.root.add_key_command(py_cui.keys.KEY_R_LOWER, self.refresh_git_status)
@@ -47,59 +45,74 @@ class AutoGitCUI:
         self.root.add_key_command(py_cui.keys.KEY_F_LOWER, self.fetch_branch)
         self.root.add_key_command(py_cui.keys.KEY_P_LOWER, self.push_branch)
         self.root.add_key_command(py_cui.keys.KEY_M_LOWER, self.show_menu)
-        self.root.set_status_bar_text('Quit - q | Refresh - r | Add all - a | Git log - l | Open Editor - e | Pull Branch - f | Push Branch - p')
+        self.root.set_status_bar_text(
+            "Quit - q | Refresh - r | Add all - a | Git log - l | Open Editor - e | Pull Branch - f | Push Branch - p"
+        )
 
         # Create the add files menu. Add color rules to color first characters based on git status
-        self.add_files_menu = self.root.add_scroll_menu('Add Files', 0, 0, row_span=2, column_span=2)
+        self.add_files_menu = self.root.add_scroll_menu("Add Files", 0, 0, row_span=2, column_span=2)
         self.add_files_menu.set_border_color(py_cui.RED_ON_BLACK)
-        self.add_files_menu.add_text_color_rule(' ', py_cui.RED_ON_BLACK, 'startswith', match_type='region', region=[0,3], include_whitespace=True)
-        self.add_files_menu.add_text_color_rule('?', py_cui.RED_ON_BLACK, 'startswith', match_type='region', region=[0,3], include_whitespace=True)
-        self.add_files_menu.add_text_color_rule(' ', py_cui.GREEN_ON_BLACK, 'notstartswith', match_type='region', region=[0,3], include_whitespace=True)
-        self.add_files_menu.add_text_color_rule('?', py_cui.GREEN_ON_BLACK, 'notstartswith', match_type='region', region=[0,3], include_whitespace=True)
+        self.add_files_menu.add_text_color_rule(
+            " ", py_cui.RED_ON_BLACK, "startswith", match_type="region", region=[0, 3], include_whitespace=True
+        )
+        self.add_files_menu.add_text_color_rule(
+            "?", py_cui.RED_ON_BLACK, "startswith", match_type="region", region=[0, 3], include_whitespace=True
+        )
+        self.add_files_menu.add_text_color_rule(
+            " ", py_cui.GREEN_ON_BLACK, "notstartswith", match_type="region", region=[0, 3], include_whitespace=True
+        )
+        self.add_files_menu.add_text_color_rule(
+            "?", py_cui.GREEN_ON_BLACK, "notstartswith", match_type="region", region=[0, 3], include_whitespace=True
+        )
 
         # Remotes menu
-        self.git_remotes_menu =self.root.add_scroll_menu('Git Remotes', 2, 0, row_span=2, column_span=2)
+        self.git_remotes_menu = self.root.add_scroll_menu("Git Remotes", 2, 0, row_span=2, column_span=2)
         self.git_remotes_menu.set_selected_color(py_cui.BLACK_ON_WHITE)
 
         # Branches menu
-        self.branch_menu = self.root.add_scroll_menu('Git Branches', 4, 0, row_span=2, column_span=2)
+        self.branch_menu = self.root.add_scroll_menu("Git Branches", 4, 0, row_span=2, column_span=2)
 
         # Commits menu
-        self.git_commits_menu = self.root.add_scroll_menu('Recent Commits', 6, 0, row_span=2, column_span=2)
+        self.git_commits_menu = self.root.add_scroll_menu("Recent Commits", 6, 0, row_span=2, column_span=2)
         self.git_commits_menu.set_selected_color(py_cui.BLACK_ON_WHITE)
 
         # Initialize the menus with current repo git info
         self.refresh_git_status()
 
         # Our text block for statuses etc.
-        self.diff_text_block = self.root.add_text_block('Git Info', 0, 2, row_span=8, column_span=6)
-        self.diff_text_block.add_text_color_rule('+', py_cui.GREEN_ON_BLACK, 'startswith')
-        self.diff_text_block.add_text_color_rule('-', py_cui.RED_ON_BLACK, 'startswith')
-        self.diff_text_block.add_text_color_rule('commit', py_cui.YELLOW_ON_BLACK, 'startswith')
-        self.diff_text_block.add_text_color_rule('Copyright', py_cui.CYAN_ON_BLACK, 'startswith')
-        self.diff_text_block.add_text_color_rule('@.*@', py_cui.CYAN_ON_BLACK, 'contains', match_type='regex')
+        self.diff_text_block = self.root.add_text_block("Git Info", 0, 2, row_span=8, column_span=6)
+        self.diff_text_block.add_text_color_rule("+", py_cui.GREEN_ON_BLACK, "startswith")
+        self.diff_text_block.add_text_color_rule("-", py_cui.RED_ON_BLACK, "startswith")
+        self.diff_text_block.add_text_color_rule("commit", py_cui.YELLOW_ON_BLACK, "startswith")
+        self.diff_text_block.add_text_color_rule("Copyright", py_cui.CYAN_ON_BLACK, "startswith")
+        self.diff_text_block.add_text_color_rule("@.*@", py_cui.CYAN_ON_BLACK, "contains", match_type="regex")
         self.diff_text_block.set_text(self.get_logo())
-        
+
         # Textboxes for new branches and commits
-        self.new_branch_textbox = self.root.add_text_box('New Branch', 8, 0, column_span=2)
-        self.commit_message_box = self.root.add_text_box('Commit Message', 8, 2, column_span=6)
+        self.new_branch_textbox = self.root.add_text_box("New Branch", 8, 0, column_span=2)
+        self.commit_message_box = self.root.add_text_box("Commit Message", 8, 2, column_span=6)
 
         # Key commands for our file menus. Enter will git add, Space will show diff
         self.add_files_menu.add_key_command(py_cui.keys.KEY_ENTER, self.add_revert_file)
         self.add_files_menu.add_key_command(py_cui.keys.KEY_SPACE, self.open_git_diff)
-        self.add_files_menu.set_help_text('Enter - git add, Space - see diff, Arrows - scroll, Esc - exit')
+        self.add_files_menu.set_help_text("Enter - git add, Space - see diff, Arrows - scroll, Esc - exit")
 
         # Enter will show remote info
         self.git_remotes_menu.add_key_command(py_cui.keys.KEY_ENTER, self.show_remote_info)
 
         # Enter will show commit diff
         self.git_commits_menu.add_key_command(py_cui.keys.KEY_ENTER, self.show_git_commit_diff)
-        self.git_commits_menu.add_text_color_rule(' ', py_cui.GREEN_ON_BLACK, 
-                                                  'notstartswith', match_type='region', 
-                                                  region=[0,7], include_whitespace=True,
-                                                  selected_color=py_cui.GREEN_ON_WHITE)
+        self.git_commits_menu.add_text_color_rule(
+            " ",
+            py_cui.GREEN_ON_BLACK,
+            "notstartswith",
+            match_type="region",
+            region=[0, 7],
+            include_whitespace=True,
+            selected_color=py_cui.GREEN_ON_WHITE,
+        )
 
-        # Enter will checkout 
+        # Enter will checkout
         self.branch_menu.add_key_command(py_cui.keys.KEY_ENTER, self.checkout_branch)
         self.branch_menu.add_key_command(py_cui.keys.KEY_SPACE, self.show_log)
 
@@ -107,212 +120,197 @@ class AutoGitCUI:
         self.new_branch_textbox.add_key_command(py_cui.keys.KEY_ENTER, self.create_new_branch)
         self.commit_message_box.add_key_command(py_cui.keys.KEY_ENTER, self.ask_to_commit)
 
-
     def get_logo(self):
-        """Grabs ascii art logo text
-        """
+        """Grabs ascii art logo text"""
 
-        logo = "         _    _ _______ ____   _____ _____ _______\n" \
-                "    /\\  | |  | |__   __/ __ \\ / ____|_   _|__   __|\n" \
-                "   /  \\ | |  | |  | | | |  | | |  __  | |    | |   \n" \
-                "  / /\\ \\| |  | |  | | | |  | | | |_ | | |    | |   \n" \
-                " / ____ \\ |__| |  | | | |__| | |__| |_| |_   | |   \n" \
-                "/_/    \\_\\____/   |_|  \\____/ \\_____|_____|  |_|   \n\n\n" \
-                "Powered by the py_cui Python Command Line UI Library:\n\n" \
-                "https://github.com/jwlodek/py_cui\n\n" \
-                "Documentation available online here: https://jwlodek.github.io/py_cui\n\n" \
-                "Star me on Github!\n\n" \
-                "Copyright (c) 2019-2020 Jakub Wlodek\n\n"
+        logo = (
+            "         _    _ _______ ____   _____ _____ _______\n"
+            "    /\\  | |  | |__   __/ __ \\ / ____|_   _|__   __|\n"
+            "   /  \\ | |  | |  | | | |  | | |  __  | |    | |   \n"
+            "  / /\\ \\| |  | |  | | | |  | | | |_ | | |    | |   \n"
+            " / ____ \\ |__| |  | | | |__| | |__| |_| |_   | |   \n"
+            "/_/    \\_\\____/   |_|  \\____/ \\_____|_____|  |_|   \n\n\n"
+            "Powered by the py_cui Python Command Line UI Library:\n\n"
+            "https://github.com/jwlodek/py_cui\n\n"
+            "Documentation available online here: https://jwlodek.github.io/py_cui\n\n"
+            "Star me on Github!\n\n"
+            "Copyright (c) 2019-2020 Jakub Wlodek\n\n"
+        )
         return logo
 
-
     def process_menu_option(self, option):
-        """TODO - process menu option from popup menu
-        """
+        """TODO - process menu option from popup menu"""
 
         self.root.set_title(option)
 
-
     def show_menu(self):
-        """Displays popup menu, with supported git commands
-        """
+        """Displays popup menu, with supported git commands"""
 
-        option_list = ['Add all', 'Push', 'Pull', 'Stash', 'Pop Stash', 'Set Editor']
-        self.root.show_menu_popup('Autogit Menu', option_list, self.process_menu_option)
-
+        option_list = ["Add all", "Push", "Pull", "Stash", "Pop Stash", "Set Editor"]
+        self.root.show_menu_popup("Autogit Menu", option_list, self.process_menu_option)
 
     def show_git_commit_diff(self):
-        """Displays diff for given git commit
-        """
+        """Displays diff for given git commit"""
 
         try:
             commit_val = self.git_commits_menu.get()[:7]
-            proc = Popen(['git', 'diff', commit_val], stdout=PIPE, stderr=PIPE)
+            proc = Popen(["git", "diff", commit_val], stdout=PIPE, stderr=PIPE)
             out, _ = proc.communicate()
             out = out.decode()
-            self.diff_text_block.set_title('Git Diff for {}'.format(commit_val))
+            self.diff_text_block.set_title(f"Git Diff for {commit_val}")
             self.diff_text_block.set_text(out)
         except:
-            self.root.show_warning_popup('Git Failed', 'Unable to read commit diff information')
-
+            self.root.show_warning_popup("Git Failed", "Unable to read commit diff information")
 
     def add_all(self):
         try:
-            proc = Popen(['git', 'add', '-A'], stdout=PIPE, stderr=PIPE)
+            proc = Popen(["git", "add", "-A"], stdout=PIPE, stderr=PIPE)
             _, _ = proc.communicate()
             self.refresh_git_status(preserve_selected=True)
         except:
-            self.root.show_warning_popup('Git Failed', 'Unable to reset file, please check git installation')
-
+            self.root.show_warning_popup("Git Failed", "Unable to reset file, please check git installation")
 
     def show_remote_info(self):
         try:
             remote = self.git_remotes_menu.get()
-            proc = Popen(['git', 'remote', 'show', '-n', remote], stdout=PIPE, stderr=PIPE)
+            proc = Popen(["git", "remote", "show", "-n", remote], stdout=PIPE, stderr=PIPE)
             out, _ = proc.communicate()
             out = out.decode()
-            self.diff_text_block.set_title('Git Remote Info')
+            self.diff_text_block.set_title("Git Remote Info")
             self.diff_text_block.set_text(out)
         except:
-            self.root.show_warning_popup('Git Error', 'Unable to open git remote info, please check git installation')
-
+            self.root.show_warning_popup("Git Error", "Unable to open git remote info, please check git installation")
 
     def open_editor(self):
         try:
-            _ = Popen(['code', '.'], stdout=PIPE, stderr=PIPE)
+            _ = Popen(["code", "."], stdout=PIPE, stderr=PIPE)
         except:
-            self.root.show_warning_popup('Open Failed', 'Please install VSCode')
+            self.root.show_warning_popup("Open Failed", "Please install VSCode")
 
     def show_log(self):
         try:
             branch = self.branch_menu.get()[2:]
-            proc = Popen(['git', '--no-pager', 'log', branch], stdout=PIPE, stderr=PIPE)
+            proc = Popen(["git", "--no-pager", "log", branch], stdout=PIPE, stderr=PIPE)
             out, _ = proc.communicate()
             out = out.decode()
-            self.diff_text_block.set_title('Git Log')
+            self.diff_text_block.set_title("Git Log")
             self.diff_text_block.set_text(out)
         except:
-            self.root.show_warning_popup('Git Error', 'Unable to open git log, please check git installation')
-
+            self.root.show_warning_popup("Git Error", "Unable to open git log, please check git installation")
 
     def create_new_branch(self):
         new_branch_name = self.new_branch_textbox.get()
         if len(new_branch_name) == 0:
-            self.root.show_error_popup('Invalid Name', 'Please enter a new branch name')
+            self.root.show_error_popup("Invalid Name", "Please enter a new branch name")
             return
         try:
-            proc = Popen(['git', 'checkout', '-b', new_branch_name])
+            proc = Popen(["git", "checkout", "-b", new_branch_name])
             _, err = proc.communicate()
             res = proc.returncode
             if res != 0:
-                self.root.show_error_popup('Create Branch Failed Failed', '{}'.format(err))
+                self.root.show_error_popup("Create Branch Failed Failed", f"{err}")
                 return
             self.refresh_git_status(preserve_selected=True)
             self.new_branch_textbox.clear()
-            self.root.show_message_popup('Success', 'Checked out branch {}'.format(new_branch_name))
+            self.root.show_message_popup("Success", f"Checked out branch {new_branch_name}")
         except:
-            self.root.show_warning_popup('Git Failed', 'Unable to checkout branch, please check git installation')
-
+            self.root.show_warning_popup("Git Failed", "Unable to checkout branch, please check git installation")
 
     def ask_to_commit(self):
-        self.root.show_yes_no_popup('Would you like to commit?', self.commit_changes)
-
+        self.root.show_yes_no_popup("Would you like to commit?", self.commit_changes)
 
     def commit_changes(self, commit):
-        if(commit):
+        if commit:
             message = self.commit_message_box.get()
             if len(message) == 0:
-                self.root.show_error_popup('Invalid Commit Message', 'Please enter a commit message')
+                self.root.show_error_popup("Invalid Commit Message", "Please enter a commit message")
                 return
-            proc = Popen(['git', 'commit', '-m', message])
+            proc = Popen(["git", "commit", "-m", message])
             _, err = proc.communicate()
             res = proc.returncode
             if res != 0:
-                self.root.show_error_popup('Create Branch Failed Failed', '{}'.format(err))
+                self.root.show_error_popup("Create Branch Failed Failed", f"{err}")
                 return
             self.refresh_git_status(preserve_selected=True)
             self.commit_message_box.clear()
-            self.root.show_message_popup('Success', 'Commited: {}'.format(message))
+            self.root.show_message_popup("Success", f"Commited: {message}")
         else:
-            self.root.show_message_popup('Cancelled', 'Commit Operation cancelled')
-
+            self.root.show_message_popup("Cancelled", "Commit Operation cancelled")
 
     def checkout_branch(self):
         try:
             target = self.branch_menu.get()[2:]
-            proc = Popen(['git', 'checkout', target])
+            proc = Popen(["git", "checkout", target])
             out, _ = proc.communicate()
             res = proc.returncode
             if res != 0:
-                self.root.show_error_popup('Checkout Failed', '{}'.format(out))
+                self.root.show_error_popup("Checkout Failed", f"{out}")
                 return
             self.refresh_git_status(preserve_selected=True)
-            self.root.show_message_popup('Success', 'Checked out branch {}'.format(target))
+            self.root.show_message_popup("Success", f"Checked out branch {target}")
         except:
-            self.root.show_warning_popup('Git Failed', 'Unable to checkout branch, please check git installation')
-
+            self.root.show_warning_popup("Git Failed", "Unable to checkout branch, please check git installation")
 
     def revert_changes(self):
         try:
             target = self.add_files_menu.get()[3:]
-            _ = Popen(['git', 'reset', 'HEAD', target])
+            _ = Popen(["git", "reset", "HEAD", target])
             self.refresh_git_status(preserve_selected=True)
         except:
-            self.root.show_warning_popup('Git Failed', 'Unable to reset file, please check git installation')
-
+            self.root.show_warning_popup("Git Failed", "Unable to reset file, please check git installation")
 
     def open_git_diff(self):
 
         target = self.add_files_menu.get()[3:]
-        self.diff_text_block.title = '{} File Diff'.format(target)
-        proc = Popen(['git', 'diff', target], stdout=PIPE, stderr=PIPE)
+        self.diff_text_block.title = f"{target} File Diff"
+        proc = Popen(["git", "diff", target], stdout=PIPE, stderr=PIPE)
         out, _ = proc.communicate()
         out = out.decode()
         self.diff_text_block.set_text(out)
 
-
     def add_revert_file(self):
         try:
             target = self.add_files_menu.get()
-            if target.startswith(' ') or target.startswith('?'):
+            if target.startswith(" ") or target.startswith("?"):
                 target = target[3:]
-                _ = Popen(['git', 'add', target], stdout=PIPE, stderr=PIPE)
+                _ = Popen(["git", "add", target], stdout=PIPE, stderr=PIPE)
                 self.refresh_git_status(preserve_selected=True)
             else:
                 self.revert_changes()
         except:
-            self.root.show_warning_popup('Git Failed', 'Unable to reset file, please check git installation')
-
+            self.root.show_warning_popup("Git Failed", "Unable to reset file, please check git installation")
 
     def refresh_git_status(self, preserve_selected=False):
 
         try:
-            proc = Popen(['git', 'branch'], stdout=PIPE, stderr=PIPE)
+            proc = Popen(["git", "branch"], stdout=PIPE, stderr=PIPE)
             out, _ = proc.communicate()
             out = out.decode().splitlines()
             self.branch_menu.clear()
             self.branch_menu.add_item_list(out)
             selected_branch = 0
             for branch in self.branch_menu.get_item_list():
-                if branch.startswith('*'):
+                if branch.startswith("*"):
                     break
                 selected_branch = selected_branch + 1
 
             remote = self.git_remotes_menu.get_selected_item_index()
-            proc = Popen(['git', 'remote'], stdout=PIPE, stderr=PIPE)
+            proc = Popen(["git", "remote"], stdout=PIPE, stderr=PIPE)
             out, _ = proc.communicate()
             out = out.decode().splitlines()
             self.git_remotes_menu.clear()
             self.git_remotes_menu.add_item_list(out)
 
-            proc = Popen(['git', '--no-pager', 'log', self.branch_menu.get()[2:], '--oneline'], stdout=PIPE, stderr=PIPE)
+            proc = Popen(
+                ["git", "--no-pager", "log", self.branch_menu.get()[2:], "--oneline"], stdout=PIPE, stderr=PIPE
+            )
             out, _ = proc.communicate()
             out = out.decode().splitlines()
             self.git_commits_menu.clear()
             self.git_commits_menu.add_item_list(out)
 
             selected_file = self.add_files_menu.get_selected_item_index()
-            proc = Popen(['git', 'status', '-s'], stdout=PIPE, stderr=PIPE)
+            proc = Popen(["git", "status", "-s"], stdout=PIPE, stderr=PIPE)
             out, _ = proc.communicate()
             out = out.decode().splitlines()
             self.add_files_menu.clear()
@@ -327,41 +325,40 @@ class AutoGitCUI:
                     self.add_files_menu.set_selected_item_index(selected_file)
 
         except FileNotFoundError:
-            self.root.show_warning_popup('Git Failed', 'Unable to get git status, please check git installation')
-
+            self.root.show_warning_popup("Git Failed", "Unable to get git status, please check git installation")
 
     def fetch_branch(self):
         try:
             target = self.branch_menu.get()[2:]
             remote = self.git_remotes_menu.get()
-            proc = Popen(['git', 'pull', remote, target, target])
+            proc = Popen(["git", "pull", remote, target, target])
             out, _ = proc.communicate()
             res = proc.returncode
             if res != 0:
-                self.root.show_error_popup('Checkout Failed', '{}'.format(out))
+                self.root.show_error_popup("Checkout Failed", f"{out}")
                 return
             self.refresh_git_status(preserve_selected=True)
-            self.root.show_message_popup('Success', 'Checked out branch {}'.format(target))
+            self.root.show_message_popup("Success", f"Checked out branch {target}")
         except FileNotFoundError:
-            self.root.show_warning_popup('Git Failed', 'Unable to checkout branch, please check git installation')
+            self.root.show_warning_popup("Git Failed", "Unable to checkout branch, please check git installation")
 
     def push_branch(self):
-        self.root.show_warning_popup('Unsupported Error', 'The git push operation is not yet supported.')
+        self.root.show_warning_popup("Unsupported Error", "The git push operation is not yet supported.")
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description='An extension on nano for editing directories in CLI.')
-    parser.add_argument('directory', help='Target directory to edit.')
+    parser = argparse.ArgumentParser(description="An extension on nano for editing directories in CLI.")
+    parser.add_argument("directory", help="Target directory to edit.")
     args = vars(parser.parse_args())
-    if 'directory' not in args.keys():
-        return '.' 
-    elif not os.path.exists(args['directory']):
-        print('ERROR - {} path does not exist'.format(args['directory']))
+    if "directory" not in args.keys():
+        return "."
+    elif not os.path.exists(args["directory"]):
+        print("ERROR - {} path does not exist".format(args["directory"]))
         exit()
-    elif not os.path.isdir(args['directory']):
-        print('ERROR - {} is not a directory'.format(args['directory']))
+    elif not os.path.isdir(args["directory"]):
+        print("ERROR - {} is not a directory".format(args["directory"]))
         exit()
-    return args['directory']
+    return args["directory"]
 
 
 dir = parse_args()
@@ -373,8 +370,8 @@ frame = AutoGitCUI(root, dir)
 # Since we want to have git changes updated as needed, we set a refresh
 # timeout to 3 seconds. Also, we need to get an updated git status for each
 # refresh, so we add a per-draw-call update funciton
-#root.set_refresh_timeout(1)
-#root.set_on_draw_update_func(lambda : frame.refresh_git_status(preserve_selected=True))
+# root.set_refresh_timeout(1)
+# root.set_on_draw_update_func(lambda : frame.refresh_git_status(preserve_selected=True))
 
 # Start our CUI
 root.start()

--- a/examples/autogit.py
+++ b/examples/autogit.py
@@ -353,10 +353,10 @@ def parse_args():
     if "directory" not in args.keys():
         return "."
     elif not os.path.exists(args["directory"]):
-        print("ERROR - {} path does not exist".format(args["directory"]))
+        print(f"ERROR - {args['directory']} path does not exist")
         exit()
     elif not os.path.isdir(args["directory"]):
-        print("ERROR - {} is not a directory".format(args["directory"]))
+        print(f"ERROR - {args['directory']} is not a directory")
         exit()
     return args["directory"]
 

--- a/examples/simple_todo_list.py
+++ b/examples/simple_todo_list.py
@@ -8,62 +8,60 @@ import py_cui
 import os
 import logging
 
-class SimpleTodoList:
 
+class SimpleTodoList:
     def __init__(self, master: py_cui.PyCUI):
 
         self.master = master
 
         # The scrolled list cells that will contain our tasks in each of the three categories
-        self.todo_scroll_cell =         self.master.add_scroll_menu('TODO',         0, 0, row_span=5, column_span=2)
-        self.in_progress_scroll_cell =  self.master.add_scroll_menu('In Progress',  0, 2, row_span=7, column_span=2)
-        self.done_scroll_cell =         self.master.add_scroll_menu('Done',         0, 4, row_span=7, column_span=2)
+        self.todo_scroll_cell = self.master.add_scroll_menu("TODO", 0, 0, row_span=5, column_span=2)
+        self.in_progress_scroll_cell = self.master.add_scroll_menu("In Progress", 0, 2, row_span=7, column_span=2)
+        self.done_scroll_cell = self.master.add_scroll_menu("Done", 0, 4, row_span=7, column_span=2)
 
         # Textbox for entering new items
-        self.new_todo_textbox = self.master.add_text_box('TODO Item', 5, 0, column_span=2)
+        self.new_todo_textbox = self.master.add_text_box("TODO Item", 5, 0, column_span=2)
 
         # buttons for rest of control
-        self.mark_in_progress = self.master.add_button('Mark in Progress', 7, 0, column_span=2,    command=self.mark_as_in_progress)
-        self.mark_in_progress = self.master.add_button('Mark As Done',     7, 2, column_span=2,    command=self.mark_as_done)
-        self.remove_todo =      self.master.add_button('Remove TODO Item', 6, 1, pady = 1,         command=self.remove_item)
-        self.new_todo_add =     self.master.add_button('Add TODO Item',    6, 0, pady =1,          command=self.add_item)
-        self.save_todo_button = self.master.add_button('Save',             7, 4, column_span=2,    command=self.save_todo_file)
+        self.mark_in_progress = self.master.add_button(
+            "Mark in Progress", 7, 0, column_span=2, command=self.mark_as_in_progress
+        )
+        self.mark_in_progress = self.master.add_button("Mark As Done", 7, 2, column_span=2, command=self.mark_as_done)
+        self.remove_todo = self.master.add_button("Remove TODO Item", 6, 1, pady=1, command=self.remove_item)
+        self.new_todo_add = self.master.add_button("Add TODO Item", 6, 0, pady=1, command=self.add_item)
+        self.save_todo_button = self.master.add_button("Save", 7, 4, column_span=2, command=self.save_todo_file)
 
         # add some custom keybindings
-        self.new_todo_textbox.add_key_command(          py_cui.keys.KEY_ENTER, self.push_and_reset)
-        self.todo_scroll_cell.add_key_command(          py_cui.keys.KEY_ENTER, self.mark_as_in_progress)
-        self.in_progress_scroll_cell.add_key_command(   py_cui.keys.KEY_ENTER, self.mark_as_done)
+        self.new_todo_textbox.add_key_command(py_cui.keys.KEY_ENTER, self.push_and_reset)
+        self.todo_scroll_cell.add_key_command(py_cui.keys.KEY_ENTER, self.mark_as_in_progress)
+        self.in_progress_scroll_cell.add_key_command(py_cui.keys.KEY_ENTER, self.mark_as_done)
         self.read_todo_file()
 
-
     def push_and_reset(self):
-        """Adds item and clears textbox. called when textbox is in focus mode and enter is pressed
-        """
+        """Adds item and clears textbox. called when textbox is in focus mode and enter is pressed"""
 
         self.add_item()
         self.new_todo_textbox.clear()
 
-
     def read_todo_file(self):
-        """Read a saved todo file
-        """
+        """Read a saved todo file"""
 
         todo = []
         in_progress = []
         done = []
-        if os.path.exists('TODO.txt'):
-            todo_fp = open('TODO.txt', 'r')
+        if os.path.exists("TODO.txt"):
+            todo_fp = open("TODO.txt", "r")
             state = 0
             line = todo_fp.readline()
             while line:
                 line = line.strip()
                 if state == 0:
-                    if line == '__IN_PROGRESS__':
+                    if line == "__IN_PROGRESS__":
                         state = 1
                     elif len(line) > 1:
                         todo.append(line)
                 elif state == 1:
-                    if line == '__DONE__':
+                    if line == "__DONE__":
                         state = 2
                     elif len(line) > 1:
                         in_progress.append(line)
@@ -76,72 +74,62 @@ class SimpleTodoList:
         self.in_progress_scroll_cell.add_item_list(in_progress)
         self.done_scroll_cell.add_item_list(done)
 
-
     def add_item(self):
-        """Add a todo item
-        """
+        """Add a todo item"""
 
-        self.todo_scroll_cell.add_item('{}'.format(self.new_todo_textbox.get()))
-
+        self.todo_scroll_cell.add_item(f"{self.new_todo_textbox.get()}")
 
     def remove_item(self):
-        """Remove a todo item
-        """
+        """Remove a todo item"""
 
         self.todo_scroll_cell.remove_selected_item()
 
-
     def mark_as_in_progress(self):
-        """Mark a todo item as inprogress. Remove it from todo scroll list, add it to in progress list, or show error popup if no tasks
-        """
+        """Mark a todo item as inprogress. Remove it from todo scroll list, add it to in progress list, or show error popup if no tasks"""
 
         in_prog = self.todo_scroll_cell.get()
         if in_prog is None:
-            self.master.show_error_popup('No Item', 'There is no item in the list to mark as in progress')
+            self.master.show_error_popup("No Item", "There is no item in the list to mark as in progress")
             return
         self.todo_scroll_cell.remove_selected_item()
         self.in_progress_scroll_cell.add_item(in_prog)
 
-
     def mark_as_done(self):
-        """Mark a inprogress item as done. Remove it from inprogress scroll list, add it to done list, or show error popup if no tasks
-        """
+        """Mark a inprogress item as done. Remove it from inprogress scroll list, add it to done list, or show error popup if no tasks"""
 
         done = self.in_progress_scroll_cell.get()
         if done is None:
-            self.master.show_error_popup('No Item', 'There is no item in the list to mark as done')
+            self.master.show_error_popup("No Item", "There is no item in the list to mark as done")
             return
         self.in_progress_scroll_cell.remove_selected_item()
         self.done_scroll_cell.add_item(done)
 
-
     def save_todo_file(self):
-        """Save the three lists in a specific format
-        """
+        """Save the three lists in a specific format"""
 
-        if os.path.exists('TODO.txt'):
-            os.remove('TODO.txt')
-        todo_fp = open('TODO.txt', 'w')
+        if os.path.exists("TODO.txt"):
+            os.remove("TODO.txt")
+        todo_fp = open("TODO.txt", "w")
         todo_items = self.todo_scroll_cell.get_item_list()
         in_progress_items = self.in_progress_scroll_cell.get_item_list()
         done_items = self.done_scroll_cell.get_item_list()
         for item in todo_items:
-            todo_fp.write(item + '\n')
-        todo_fp.write('__IN_PROGRESS__' + '\n')
+            todo_fp.write(item + "\n")
+        todo_fp.write("__IN_PROGRESS__" + "\n")
         for item in in_progress_items:
-            todo_fp.write(item + '\n')
-        todo_fp.write('__DONE__' + '\n')
+            todo_fp.write(item + "\n")
+        todo_fp.write("__DONE__" + "\n")
         for item in done_items:
-            todo_fp.write(item + '\n')
+            todo_fp.write(item + "\n")
         todo_fp.close()
-        self.master.show_message_popup('Saved', 'Your TODO list has been saved!')
+        self.master.show_message_popup("Saved", "Your TODO list has been saved!")
 
 
 # Create the CUI, pass it to the wrapper object, and start it
 root = py_cui.PyCUI(8, 6)
-root.set_title('CUI TODO List')
-#root.enable_logging(logging_level=logging.DEBUG)
+root.set_title("CUI TODO List")
+# root.enable_logging(logging_level=logging.DEBUG)
 root.enable_logging(logging_level=logging.ERROR)
-#root.toggle_live_debug_mode()
+# root.toggle_live_debug_mode()
 s = SimpleTodoList(root)
 root.start()

--- a/examples/snano.py
+++ b/examples/snano.py
@@ -12,11 +12,10 @@ import os
 import argparse
 import py_cui.colors
 
-__version__ = '0.0.1'
+__version__ = "0.0.1"
 
 
 class SuperNano:
-
     def __init__(self, root: py_cui.PyCUI, dir):
 
         # Wrapper class takes its parent PyCUI object
@@ -29,7 +28,7 @@ class SuperNano:
         self.root.add_key_command(py_cui.keys.KEY_S_LOWER, self.save_opened_file)
 
         # Add a file selection menu
-        self.file_menu = self.root.add_scroll_menu('Directory Files', 0, 0, row_span=5, column_span=2)
+        self.file_menu = self.root.add_scroll_menu("Directory Files", 0, 0, row_span=5, column_span=2)
 
         # With ENTER key press, we open the selected file or directory, DELETE will delete the selected file or directory
         # See the callback functions for how these operations are performed
@@ -39,10 +38,12 @@ class SuperNano:
         # To better distingusish directories, add a color rule that is used to color directory names green
         # First parameter is a regex, second is color, third is how the rule should check the regex against the line.
         # A region match type means to color only the specified region.
-        self.file_menu.add_text_color_rule('<DIR>', py_cui.GREEN_ON_BLACK, 'startswith', match_type='region', region=[5,1000])
+        self.file_menu.add_text_color_rule(
+            "<DIR>", py_cui.GREEN_ON_BLACK, "startswith", match_type="region", region=[5, 1000]
+        )
 
         # Add a textbox for listing the current directory, set initial text to current directory
-        self.current_dir_box = self.root.add_text_box('Current Directory', 6, 0, column_span=2)
+        self.current_dir_box = self.root.add_text_box("Current Directory", 6, 0, column_span=2)
         self.current_dir_box.set_text(self.dir)
 
         # You can manually enter directory path, and ENTER will try to open it
@@ -52,24 +53,23 @@ class SuperNano:
         self.open_new_directory()
 
         # Add main text block for edition text.
-        self.edit_text_block = self.root.add_text_block('Open file', 0, 2, row_span=7, column_span=6)
+        self.edit_text_block = self.root.add_text_block("Open file", 0, 2, row_span=7, column_span=6)
 
         # Add a textbox for adding new files on ENTER key
-        self.new_file_textbox = self.root.add_text_box('Add New File', 5, 0, column_span=2)
+        self.new_file_textbox = self.root.add_text_box("Add New File", 5, 0, column_span=2)
         self.new_file_textbox.add_key_command(py_cui.keys.KEY_ENTER, self.add_new_file)
-
 
     def open_new_directory(self):
 
         # Get the text in the current directory textbox, check if it exists
         target = self.current_dir_box.get()
         if len(target) == 0:
-            target = '.'
+            target = "."
         elif not os.path.exists(target):
-            self.root.show_error_popup('Does not exist', 'ERROR - {} path does not exist'.format(target))
+            self.root.show_error_popup("Does not exist", f"ERROR - {target} path does not exist")
             return
         elif not os.path.isdir(target):
-            self.root.show_error_popup('Not a Dir', 'ERROR - {} is not a directory'.format(target))
+            self.root.show_error_popup("Not a Dir", f"ERROR - {target} is not a directory")
             return
         target = os.path.abspath(target)
         self.current_dir_box.set_text(target)
@@ -77,17 +77,16 @@ class SuperNano:
 
         # If it does exist, list contents, and create list of files/dirs for file menu
         files = []
-        files.append('<DIR> ..')
+        files.append("<DIR> ..")
         dir_contents = os.listdir(self.dir)
         for elem in dir_contents:
             if os.path.isfile(os.path.join(self.dir, elem)):
                 files.append(elem)
             else:
-                files.append('<DIR> ' + elem)
+                files.append("<DIR> " + elem)
 
         self.file_menu.clear()
         self.file_menu.add_item_list(files)
-        
 
     def add_new_file(self):
 
@@ -100,11 +99,10 @@ class SuperNano:
         self.edit_text_block.clear()
         self.new_file_textbox.clear()
 
-
     def open_file_dir(self):
         # Open file or directory by checking selected item in file menu.
         filename = self.file_menu.get()
-        if filename.startswith('<DIR>'):
+        if filename.startswith("<DIR>"):
             # if directory, set the current dir box to selected one, and refresh
             self.current_dir_box.set_text(os.path.join(self.dir, filename[6:]))
             self.open_new_directory()
@@ -112,56 +110,56 @@ class SuperNano:
             try:
                 # Otherwise, if it is a file, put it in the text block
                 self.edit_text_block.text_color_rules = []
-                fp = open(os.path.join(self.dir, filename), 'r')
+                fp = open(os.path.join(self.dir, filename), "r")
                 text = fp.read()
                 fp.close()
                 self.edit_text_block.set_text(text)
                 self.edit_text_block.set_title(filename)
             except:
                 # if we get an error, it wasn't a text file, so show warning poup
-                self.root.show_warning_popup('Not a text file', 'The selected file could not be opened - not a text file')
-
+                self.root.show_warning_popup(
+                    "Not a text file", "The selected file could not be opened - not a text file"
+                )
 
     def save_opened_file(self):
         # If we have an opened file, save it to the disk
-        if self.edit_text_block.get_title() != 'Open file':
-            fp = open(os.path.join(self.dir, self.edit_text_block.get_title()), 'w')
+        if self.edit_text_block.get_title() != "Open file":
+            fp = open(os.path.join(self.dir, self.edit_text_block.get_title()), "w")
             fp.write(self.edit_text_block.get())
             fp.close()
-            self.root.show_message_popup('Saved', 'Your file has been saved as {}'.format(self.edit_text_block.get_title()))
+            self.root.show_message_popup("Saved", f"Your file has been saved as {self.edit_text_block.get_title()}")
         else:
-            self.root.show_error_popup('No File Opened', 'Please open a file before saving it.')
-
+            self.root.show_error_popup("No File Opened", "Please open a file before saving it.")
 
     def delete_selected_file(self):
         # If we have an opened file, delete it from the disk
-        if self.edit_text_block.get_title() != 'Open file':
+        if self.edit_text_block.get_title() != "Open file":
             try:
                 os.remove(os.path.join(self.dir, self.edit_text_block.get_title()))
                 self.edit_text_block.clear()
-                self.edit_text_block.set_title('Open file')
+                self.edit_text_block.set_title("Open file")
                 self.file_menu.remove_selected_item()
             except OSError:
-                self.root.show_error_popup('OS Error', 'Operation could not be completed due to an OS error.')
+                self.root.show_error_popup("OS Error", "Operation could not be completed due to an OS error.")
         else:
-            self.root.show_error_popup('No File Opened', 'Please open a file before deleting it.')
+            self.root.show_error_popup("No File Opened", "Please open a file before deleting it.")
 
 
 def parse_args():
 
     # Parse some basic arguments (requires target directory)
-    parser = argparse.ArgumentParser(description='An extension on nano for editing directories in CLI.')
-    parser.add_argument('directory', help='Target directory to edit.')
+    parser = argparse.ArgumentParser(description="An extension on nano for editing directories in CLI.")
+    parser.add_argument("directory", help="Target directory to edit.")
     args = vars(parser.parse_args())
-    if 'directory' not in args.keys():
-        return '.' 
-    elif not os.path.exists(args['directory']):
-        print('ERROR - {} path does not exist'.format(args['directory']))
+    if "directory" not in args.keys():
+        return "."
+    elif not os.path.exists(args["directory"]):
+        print("ERROR - {} path does not exist".format(args["directory"]))
         exit()
-    elif not os.path.isdir(args['directory']):
-        print('ERROR - {} is not a directory'.format(args['directory']))
+    elif not os.path.isdir(args["directory"]):
+        print("ERROR - {} is not a directory".format(args["directory"]))
         exit()
-    return args['directory']
+    return args["directory"]
 
 
 # Collect some argument information
@@ -169,7 +167,7 @@ dir = parse_args()
 
 # Initialize the PyCUI object, and set the title
 root = py_cui.PyCUI(7, 8)
-root.set_title('Super Nano v{}'.format(__version__))
+root.set_title(f"Super Nano v{__version__}")
 
 # Create the wrapper instance object.
 frame = SuperNano(root, dir)

--- a/examples/snano.py
+++ b/examples/snano.py
@@ -154,10 +154,10 @@ def parse_args():
     if "directory" not in args.keys():
         return "."
     elif not os.path.exists(args["directory"]):
-        print("ERROR - {} path does not exist".format(args["directory"]))
+        print(f"ERROR - {args['directory']} path does not exist")
         exit()
     elif not os.path.isdir(args["directory"]):
-        print("ERROR - {} is not a directory".format(args["directory"]))
+        print(f"ERROR - {args['directory']} is not a directory")
         exit()
     return args["directory"]
 

--- a/py_cui/controls/slider.py
+++ b/py_cui/controls/slider.py
@@ -4,7 +4,6 @@ import py_cui.popups
 
 
 class SliderImplementation(py_cui.ui.UIImplementation):
-
     def __init__(self, min_val, max_val, init_val, step, logger):
         super().__init__(logger)
 
@@ -16,10 +15,7 @@ class SliderImplementation(py_cui.ui.UIImplementation):
         self._bar_char = "#"
 
         if self._cur_val < self._min_val or self._cur_val > self._max_val:
-            raise py_cui.errors.PyCUIInvalidValue(
-                'initial value must be between {} and {}'
-                .format(self._min_val, self._max_val))
-
+            raise py_cui.errors.PyCUIInvalidValue(f"initial value must be between {self._min_val} and {self._max_val}")
 
     def set_bar_char(self, char):
         """
@@ -31,9 +27,8 @@ class SliderImplementation(py_cui.ui.UIImplementation):
             Character to represent progressive bar.
         """
 
-        assert len(char) == 1, "char should contain exactly one character, got {} instead.".format(len(char))
+        assert len(char) == 1, f"char should contain exactly one character, got {len(char)} instead."
         self._bar_char = char
-
 
     def update_slider_value(self, offset: int) -> float:
         """
@@ -51,7 +46,7 @@ class SliderImplementation(py_cui.ui.UIImplementation):
         """
 
         # direction , 1 raise value, -1 lower value
-        self._cur_val += (offset * self._step)
+        self._cur_val += offset * self._step
 
         if self._cur_val < self._min_val:
             self._cur_val = self._min_val
@@ -60,7 +55,6 @@ class SliderImplementation(py_cui.ui.UIImplementation):
             self._cur_val = self._max_val
 
         return self._cur_val
-
 
     def get_slider_value(self):
         """
@@ -73,7 +67,6 @@ class SliderImplementation(py_cui.ui.UIImplementation):
         """
 
         return self._cur_val
-
 
     def set_slider_step(self, step):
         """
@@ -104,14 +97,15 @@ class SliderWidget(py_cui.widgets.Widget, SliderImplementation):
         Initial value of the slider
     """
 
-    def __init__(self, id, title, grid, row, column, row_span, column_span,
-                 padx, pady, logger, min_val, max_val, step, init_val):
+    def __init__(
+        self, id, title, grid, row, column, row_span, column_span, padx, pady, logger, min_val, max_val, step, init_val
+    ):
 
         SliderImplementation.__init__(self, min_val, max_val, init_val, step, logger)
 
-        py_cui.widgets.Widget.__init__(self, id, title, grid, row, column,
-                                       row_span, column_span, padx,
-                                       pady, logger, selectable=True)
+        py_cui.widgets.Widget.__init__(
+            self, id, title, grid, row, column, row_span, column_span, padx, pady, logger, selectable=True
+        )
 
         self._title_enabled = True
         self._border_enabled = True
@@ -119,45 +113,32 @@ class SliderWidget(py_cui.widgets.Widget, SliderImplementation):
         self._alignment = "mid"
         self.set_help_text("Focus mode on Slider. Use left/right to adjust value. Esc to exit.")
 
-
     def toggle_title(self):
-        """Toggles visibility of the widget's name.
-        """
+        """Toggles visibility of the widget's name."""
 
         self._title_enabled = not self._title_enabled
 
-
     def toggle_border(self):
-        """Toggles visibility of the widget's border.
-        """
+        """Toggles visibility of the widget's border."""
 
         self._border_enabled = not self._border_enabled
 
-
     def toggle_value(self):
-        """Toggles visibility of the widget's current value in integer.
-        """
+        """Toggles visibility of the widget's current value in integer."""
 
         self._display_value = not self._display_value
 
-
     def align_to_top(self):
-        """Aligns widget height to top.
-        """
+        """Aligns widget height to top."""
         self._alignment = "top"
 
-
     def align_to_middle(self):
-        """Aligns widget height to middle. default configuration.
-        """
+        """Aligns widget height to middle. default configuration."""
         self._alignment = "mid"
 
-
     def align_to_bottom(self):
-        """Aligns widget height to bottom.
-        """
+        """Aligns widget height to bottom."""
         self._alignment = "btm"
-
 
     def _custom_draw_with_border(self, start_y: int, content: str):
         """
@@ -193,7 +174,6 @@ class SliderWidget(py_cui.widgets.Widget, SliderImplementation):
 
         renderer.unset_color_mode(ui_element.get_border_color())
 
-
     def _generate_bar(self, width: int) -> str:
         """
         Internal implementation to generate progression bar.
@@ -217,14 +197,14 @@ class SliderWidget(py_cui.widgets.Widget, SliderImplementation):
             bar = self._bar_char * int((width * (self._cur_val - self._min_val)) / (self._max_val - self._min_val))
             progress = (self._bar_char * len(min_string) + bar)[: -len(value_str)] + value_str
         else:
-            progress = self._bar_char * int((width * (self._cur_val - self._min_val)) / (self._max_val - self._min_val))
+            progress = self._bar_char * int(
+                (width * (self._cur_val - self._min_val)) / (self._max_val - self._min_val)
+            )
 
         return progress
 
-
     def _draw(self):
-        """Override of base class draw function.
-        """
+        """Override of base class draw function."""
 
         super()._draw()
         self._renderer.set_color_mode(self._color)
@@ -240,9 +220,7 @@ class SliderWidget(py_cui.widgets.Widget, SliderImplementation):
             text_y_pos = self._start_y + height - visual_height - 1
 
         if self._title_enabled:
-            self._renderer.draw_text(
-                self, self.get_title(), text_y_pos, selected=self.is_selected(), bordered=False
-            )
+            self._renderer.draw_text(self, self.get_title(), text_y_pos, selected=self.is_selected(), bordered=False)
             text_y_pos += 1
 
         if self._border_enabled:
@@ -255,7 +233,6 @@ class SliderWidget(py_cui.widgets.Widget, SliderImplementation):
             )
 
         self._renderer.unset_color_mode(self._color)
-
 
     def _handle_key_press(self, key_pressed):
         """

--- a/py_cui/dialogs/filedialog.py
+++ b/py_cui/dialogs/filedialog.py
@@ -26,10 +26,9 @@ def is_filepath_hidden(path):
         True if name starts with '.', or has hidden attribute in OS
     """
 
-
     name = os.path.basename(path)
-    marked_hidden = name.startswith('.')
-    if sys.platform != 'win32':
+    marked_hidden = name.startswith(".")
+    if sys.platform != "win32":
         return marked_hidden
     else:
         return bool(os.stat(path).st_file_attributes & stat.FILE_ATTRIBUTE_HIDDEN) or marked_hidden
@@ -53,8 +52,7 @@ class FileDirElem:
     """
 
     def __init__(self, elem_type, name, fullpath, ascii_icons=False):
-        """Intializer for FilDirElem
-        """
+        """Intializer for FilDirElem"""
 
         self._type = elem_type
         self._name = name
@@ -63,13 +61,12 @@ class FileDirElem:
         # Use unicode icons of folder and file, or use text instead
         # for compatibility reasons.
         if not ascii_icons:
-            self._folder_icon = '\U0001f4c1'
-            # Folder icon is two characters, so 
-            self._file_icon = '\U0001f5ce' + ' '
+            self._folder_icon = "\U0001f4c1"
+            # Folder icon is two characters, so
+            self._file_icon = "\U0001f5ce" + " "
         else:
-            self._folder_icon = '<DIR>'
-            self._file_icon = '     '
-
+            self._folder_icon = "<DIR>"
+            self._file_icon = "     "
 
     def get_path(self):
         """Getter for path
@@ -82,7 +79,6 @@ class FileDirElem:
 
         return self._path
 
-
     def __str__(self):
         """Override of to-string function
 
@@ -92,11 +88,10 @@ class FileDirElem:
             Icon and name of dir or file
         """
 
-        if self._type == 'file':
-            return '{} {}'.format(self._file_icon, self._name)
+        if self._type == "file":
+            return f"{self._file_icon} {self._name}"
         else:
-            return '{} {}'.format(self._folder_icon, self._name)
-
+            return f"{self._folder_icon} {self._name}"
 
 
 class FileSelectImplementation(py_cui.ui.MenuImplementation):
@@ -114,13 +109,13 @@ class FileSelectImplementation(py_cui.ui.MenuImplementation):
         List of file extensions to show as visible
     """
 
-
-    def __init__(self, initial_loc, dialog_type, ascii_icons, logger, limit_extensions = [], show_hidden=False):
-        """Initalizer for the file select menu implementation. Includes some logic for getting list of file and folders.
+    def __init__(self, initial_loc, dialog_type, ascii_icons, logger, limit_extensions=[], show_hidden=False):
+        """Initializer for the file select menu implementation.
+        Includes some logic for getting list of file and folders.
         """
 
         super().__init__(logger)
-        
+
         self._current_dir = os.path.abspath(initial_loc)
         self._ascii_icons = ascii_icons
         self._dialog_type = dialog_type
@@ -129,10 +124,8 @@ class FileSelectImplementation(py_cui.ui.MenuImplementation):
         self._limit_extensions = limit_extensions
         self.refresh_view()
 
-
     def refresh_view(self):
-        """Function that refreshes the current list of files and folders in view
-        """
+        """Function that refreshes the current list of files and folders in view"""
 
         if not os.path.exists(self._current_dir):
             raise FileNotFoundError
@@ -146,25 +139,25 @@ class FileSelectImplementation(py_cui.ui.MenuImplementation):
                 else:
                     item_path = os.path.join(self._current_dir, item)
                     if os.path.isdir(item_path):
-                        dirs.append(FileDirElem('dir', item, item_path, ascii_icons=self._ascii_icons))
+                        dirs.append(FileDirElem("dir", item, item_path, ascii_icons=self._ascii_icons))
                     else:
                         if len(self._limit_extensions) > 0:
                             for ext in self._limit_extensions:
                                 if item.endswith(ext):
-                                    files.append(FileDirElem('file', item, item_path, ascii_icons=self._ascii_icons))
+                                    files.append(FileDirElem("file", item, item_path, ascii_icons=self._ascii_icons))
                                     break
                         else:
-                            files.append(FileDirElem('file', item, item_path, ascii_icons=self._ascii_icons))
+                            files.append(FileDirElem("file", item, item_path, ascii_icons=self._ascii_icons))
 
             # If not at root of file system, add a .. directory.
             up_dir = os.path.dirname(self._current_dir)
             if self._current_dir != up_dir:
-                self.add_item(FileDirElem('dir', '..', up_dir, ascii_icons=self._ascii_icons))
+                self.add_item(FileDirElem("dir", "..", up_dir, ascii_icons=self._ascii_icons))
 
-            if self._dialog_type == 'openfile' or self._dialog_type == 'saveas':
+            if self._dialog_type == "openfile" or self._dialog_type == "saveas":
                 self.add_item_list(dirs)
                 self.add_item_list(files)
-            elif self._dialog_type == 'opendir':
+            elif self._dialog_type == "opendir":
                 self.add_item_list(dirs)
 
 
@@ -181,22 +174,46 @@ class FileSelectElement(py_cui.ui.UIElement, FileSelectImplementation):
         Runs command even if there are no menu items (passes None)
     """
 
-    def __init__(self, root, initial_dir, dialog_type, ascii_icons, title, color, command, renderer, logger, limit_extensions=[]):
-        """Initializer for MenuPopup. Uses MenuImplementation as base
-        """
+    def __init__(
+        self, root, initial_dir, dialog_type, ascii_icons, title, color, command, renderer, logger, limit_extensions=[]
+    ):
+        """Initializer for MenuPopup. Uses MenuImplementation as base"""
 
         py_cui.ui.UIElement.__init__(self, 0, os.path.abspath(initial_dir), renderer, logger)
-        FileSelectImplementation.__init__(self, initial_dir, dialog_type, ascii_icons, logger, limit_extensions=limit_extensions)
-        self._command              = command
-        self._parent_dialog        = root
+        FileSelectImplementation.__init__(
+            self, initial_dir, dialog_type, ascii_icons, logger, limit_extensions=limit_extensions
+        )
+        self._command = command
+        self._parent_dialog = root
         self._text_color_rules = [
-            py_cui.colors.ColorRule('\U0001f4c1', py_cui.BLUE_ON_BLACK, py_cui.WHITE_ON_BLUE,'startswith', 'region', [3, 1000], False, logger),
-            py_cui.colors.ColorRule('<DIR>', py_cui.BLUE_ON_BLACK, py_cui.WHITE_ON_BLUE, 'startswith', 'region', [6, 1000], False, logger),
-            py_cui.colors.ColorRule('     ', py_cui.WHITE_ON_BLACK, py_cui.BLACK_ON_WHITE, 'startswith', 'region', [6, 1000], True, logger),
-            py_cui.colors.ColorRule('\U0001f5ce', py_cui.WHITE_ON_BLACK, py_cui.BLACK_ON_WHITE, 'startswith', 'region', [3, 1000], False, logger)
+            py_cui.colors.ColorRule(
+                "\U0001f4c1",
+                py_cui.BLUE_ON_BLACK,
+                py_cui.WHITE_ON_BLUE,
+                "startswith",
+                "region",
+                [3, 1000],
+                False,
+                logger,
+            ),
+            py_cui.colors.ColorRule(
+                "<DIR>", py_cui.BLUE_ON_BLACK, py_cui.WHITE_ON_BLUE, "startswith", "region", [6, 1000], False, logger
+            ),
+            py_cui.colors.ColorRule(
+                "     ", py_cui.WHITE_ON_BLACK, py_cui.BLACK_ON_WHITE, "startswith", "region", [6, 1000], True, logger
+            ),
+            py_cui.colors.ColorRule(
+                "\U0001f5ce",
+                py_cui.WHITE_ON_BLACK,
+                py_cui.BLACK_ON_WHITE,
+                "startswith",
+                "region",
+                [3, 1000],
+                False,
+                logger,
+            ),
         ]
-        #self._run_command_if_none  = run_command_if_none
-
+        # self._run_command_if_none  = run_command_if_none
 
     def get_absolute_start_pos(self):
         """Override of base function. Uses the parent element do compute start position
@@ -208,10 +225,9 @@ class FileSelectElement(py_cui.ui.UIElement, FileSelectImplementation):
         """
 
         parent_start_x, parent_start_y = self._parent_dialog.get_start_position()
-        start_x = (parent_start_x + 3 + self._parent_dialog._padx)
-        start_y = (parent_start_y + self._parent_dialog._pady + 3)
+        start_x = parent_start_x + 3 + self._parent_dialog._padx
+        start_y = parent_start_y + self._parent_dialog._pady + 3
         return start_x, start_y
-
 
     def get_absolute_stop_pos(self):
         """Override of base function. Uses the parent element do compute stop position
@@ -223,10 +239,9 @@ class FileSelectElement(py_cui.ui.UIElement, FileSelectImplementation):
         """
 
         parent_stop_x, parent_stop_y = self._parent_dialog.get_stop_position()
-        stop_x = (parent_stop_x - 3 - self._parent_dialog._padx)
-        stop_y = (parent_stop_y - self._parent_dialog._pady - 7)
+        stop_x = parent_stop_x - 3 - self._parent_dialog._padx
+        stop_y = parent_stop_y - self._parent_dialog._pady - 7
         return stop_x, stop_y
-
 
     def _handle_key_press(self, key_pressed):
         """Override of base handle key press function
@@ -247,16 +262,16 @@ class FileSelectElement(py_cui.ui.UIElement, FileSelectImplementation):
                 try:
                     self.refresh_view()
                 except FileNotFoundError:
-                    self._parent_dialog.display_warning('Selected directory does not exist!')
+                    self._parent_dialog.display_warning("Selected directory does not exist!")
                     self._current_dir = old_dir
                     self.refresh_view()
                 except PermissionError:
-                    self._parent_dialog.display_warning('Permission Error Accessing: {} !'.format(self._current_dir))
+                    self._parent_dialog.display_warning(f"Permission Error Accessing: {self._current_dir} !")
                     self._current_dir = old_dir
                     self.refresh_view()
                 finally:
                     self.set_title(self._current_dir)
-            elif self._parent_dialog._dialog_type == 'openfile':
+            elif self._parent_dialog._dialog_type == "openfile":
                 self._parent_dialog._submit(self.get()._path)
             else:
                 pass
@@ -275,10 +290,8 @@ class FileSelectElement(py_cui.ui.UIElement, FileSelectImplementation):
         if key_pressed == py_cui.keys.KEY_PAGE_DOWN:
             self._jump_down(viewport_height)
 
-
     def _draw(self):
-        """Overrides base class draw function
-        """
+        """Overrides base class draw function"""
 
         self._renderer.set_color_mode(self._color)
         self._renderer.draw_border(self)
@@ -311,21 +324,18 @@ class FileNameInput(py_cui.ui.UIElement, py_cui.ui.TextBoxImplementation):
         parent dialog widget or popup
     """
 
-
     def __init__(self, parent_dialog, title, initial_dir, renderer, logger):
-        """Initializer for the FormFieldElement class
-        """
+        """Initializer for the FormFieldElement class"""
 
         self._parent_dialog = parent_dialog
         py_cui.ui.UIElement.__init__(self, 0, title, renderer, logger)
         py_cui.ui.TextBoxImplementation.__init__(self, title, False, logger)
-        self._help_text = 'Press Tab to move to the next field, or Enter to submit.'
+        self._help_text = "Press Tab to move to the next field, or Enter to submit."
         self.set_text(initial_dir)
         self._padx = 0
         self._pady = 0
         self._selected = False
         self.update_height_width()
-
 
     def get_absolute_start_pos(self):
         """Override of base function. Uses the parent element do compute start position
@@ -338,10 +348,9 @@ class FileNameInput(py_cui.ui.UIElement, py_cui.ui.TextBoxImplementation):
 
         parent_start_x, _ = self._parent_dialog.get_start_position()
         _, parent_stop_y = self._parent_dialog.get_stop_position()
-        start_x = (parent_start_x + 4 + self._parent_dialog._padx)
-        start_y = (parent_stop_y - self._parent_dialog._pady - 7)
+        start_x = parent_start_x + 4 + self._parent_dialog._padx
+        start_y = parent_stop_y - self._parent_dialog._pady - 7
         return start_x, start_y
-
 
     def get_absolute_stop_pos(self):
         """Override of base function. Uses the parent element do compute stop position
@@ -354,31 +363,27 @@ class FileNameInput(py_cui.ui.UIElement, py_cui.ui.TextBoxImplementation):
 
         _, parent_width = self._parent_dialog.get_absolute_dimensions()
         parent_stop_x, parent_stop_y = self._parent_dialog.get_stop_position()
-        stop_x = (parent_stop_x - 4 - int(3 * parent_width / 7))
-        stop_y = (parent_stop_y - self._parent_dialog._pady - 2)
+        stop_x = parent_stop_x - 4 - int(3 * parent_width / 7)
+        stop_y = parent_stop_y - self._parent_dialog._pady - 2
         return stop_x, stop_y
 
-
     def update_height_width(self):
-        """Override of base class. Updates text field variables for form field
-        """
+        """Override of base class. Updates text field variables for form field"""
 
         super().update_height_width()
-        padx, pady              = self.get_padding()
-        start_x, start_y        = self.get_start_position()
-        height, width           = self.get_absolute_dimensions()
-        self._cursor_text_pos   = 0
-        self._cursor_x          = start_x + 2 + padx
-        self._initial_cursor    = self._cursor_x
-        self._cursor_max_left   = self._cursor_x
-        self._cursor_max_right  = start_x + width - 1 - pady
-        self._cursor_y          = start_y + int(height / 2) + 1
-        self._viewport_width    = self._cursor_max_right - self._cursor_max_left
-
+        padx, pady = self.get_padding()
+        start_x, start_y = self.get_start_position()
+        height, width = self.get_absolute_dimensions()
+        self._cursor_text_pos = 0
+        self._cursor_x = start_x + 2 + padx
+        self._initial_cursor = self._cursor_x
+        self._cursor_max_left = self._cursor_x
+        self._cursor_max_right = start_x + width - 1 - pady
+        self._cursor_y = start_y + int(height / 2) + 1
+        self._viewport_width = self._cursor_max_right - self._cursor_max_left
 
     def _handle_key_press(self, key_pressed):
-        """Handles text input for the field. Called by parent
-        """
+        """Handles text input for the field. Called by parent"""
 
         if key_pressed == py_cui.keys.KEY_LEFT_ARROW:
             self._move_left()
@@ -398,39 +403,37 @@ class FileNameInput(py_cui.ui.UIElement, py_cui.ui.TextBoxImplementation):
             old_dir = self._parent_dialog._file_dir_select._current_dir
             new_elem = os.path.join(old_dir, self.get())
             try:
-                if self._parent_dialog._dialog_type == 'saveas':
+                if self._parent_dialog._dialog_type == "saveas":
                     self._parent_dialog._submit(new_elem)
 
-                elif self._parent_dialog._dialog_type == 'opendir':
+                elif self._parent_dialog._dialog_type == "opendir":
                     os.mkdir(new_elem)
                     self._parent_dialog._file_dir_select.refresh_view()
 
                 else:
-                    fp = open(new_elem, 'w')
+                    fp = open(new_elem, "w")
                     fp.close()
                     self._parent_dialog._file_dir_select.refresh_view()
-                    
+
             except FileExistsError:
-                self._parent_dialog.display_warning('File/Directory already exists!')
+                self._parent_dialog.display_warning("File/Directory already exists!")
             except PermissionError:
-                self._parent_dialog.display_warning('Insufficient permissions!')
+                self._parent_dialog.display_warning("Insufficient permissions!")
             finally:
                 self.clear()
 
-
     def _draw(self):
-        """Draw function for the field. Called from parent. Essentially the same as a TextboxPopup
-        """
+        """Draw function for the field. Called from parent. Essentially the same as a TextboxPopup"""
 
         self._renderer.set_color_mode(self._parent_dialog._color)
         self._renderer.set_color_rules([])
         self._renderer.draw_text(self, self._title, self._cursor_y - 2, bordered=False, selected=self._selected)
         self._renderer.draw_border(self, fill=False, with_title=False)
         render_text = self._text
-        if len(self._text) >self._viewport_width:
+        if len(self._text) > self._viewport_width:
             end = len(self._text) - (self._viewport_width)
             if self._cursor_text_pos < end:
-                render_text = self._text[self._cursor_text_pos:self._cursor_text_pos + (self._viewport_width)]
+                render_text = self._text[self._cursor_text_pos : self._cursor_text_pos + (self._viewport_width)]
             else:
                 render_text = self._text[end:]
 
@@ -454,21 +457,18 @@ class FileDialogButton(py_cui.ui.UIElement):
         0 for submit button, 1 for cancel button
     """
 
-
     def __init__(self, parent_dialog, statusbar_msg, command, button_num, *args):
-        """Initializer for Button Widget
-        """
+        """Initializer for Button Widget"""
 
         super().__init__(*args)
         self._parent_dialog = parent_dialog
-        if self.get_title() == 'OK':
+        if self.get_title() == "OK":
             self.set_color(py_cui.GREEN_ON_BLACK)
         else:
             self.set_color(py_cui.RED_ON_BLACK)
         self.set_help_text(statusbar_msg)
         self.command = command
         self._button_num = button_num
-
 
     def get_absolute_start_pos(self):
         """Override of base function. Uses the parent element do compute start position
@@ -481,10 +481,9 @@ class FileDialogButton(py_cui.ui.UIElement):
 
         _, parent_width = self._parent_dialog.get_absolute_dimensions()
         parent_stop_x, parent_stop_y = self._parent_dialog.get_stop_position()
-        start_x = (parent_stop_x - 4 - int((3 - self._button_num) * parent_width / 7))
-        start_y = (parent_stop_y - self._parent_dialog._pady - 7)
+        start_x = parent_stop_x - 4 - int((3 - self._button_num) * parent_width / 7)
+        start_y = parent_stop_y - self._parent_dialog._pady - 7
         return start_x, start_y
-
 
     def get_absolute_stop_pos(self):
         """Override of base function. Uses the parent element do compute stop position
@@ -497,13 +496,12 @@ class FileDialogButton(py_cui.ui.UIElement):
 
         _, parent_width = self._parent_dialog.get_absolute_dimensions()
         parent_stop_x, parent_stop_y = self._parent_dialog.get_stop_position()
-        stop_x = (parent_stop_x - 4 - int((2 - self._button_num) * parent_width / 7))
-        stop_y = (parent_stop_y - self._parent_dialog._pady - 2)
+        stop_x = parent_stop_x - 4 - int((2 - self._button_num) * parent_width / 7)
+        stop_y = parent_stop_y - self._parent_dialog._pady - 2
         return stop_x, stop_y
 
-
     def _handle_mouse_press(self, x, y):
-        """Handles mouse presses 
+        """Handles mouse presses
 
         Parameters
         ----------
@@ -515,7 +513,6 @@ class FileDialogButton(py_cui.ui.UIElement):
 
         super()._handle_mouse_press(x, y)
         self.perform_command()
-
 
     def _handle_key_press(self, key_pressed):
         """Override of base class, adds ENTER listener that runs the button's command
@@ -530,14 +527,15 @@ class FileDialogButton(py_cui.ui.UIElement):
         if key_pressed == py_cui.keys.KEY_ENTER:
             self.perform_command()
 
-    
     def perform_command(self):
         if self.command is not None:
             if self._button_num == 1:
-                if self._parent_dialog._dialog_type == 'saveas':
+                if self._parent_dialog._dialog_type == "saveas":
                     # If submitting 'saveas', we return the currently opened dir joined with the filename
-                    res = os.path.join(self._parent_dialog._file_dir_select._current_dir, self._parent_dialog._filename_input.get())
-                elif self._parent_dialog._dialog_type == 'opendir':
+                    res = os.path.join(
+                        self._parent_dialog._file_dir_select._current_dir, self._parent_dialog._filename_input.get()
+                    )
+                elif self._parent_dialog._dialog_type == "opendir":
                     # Otherwise, return the currently opened directory
                     res = self._parent_dialog._file_dir_select._current_dir
                 else:
@@ -545,14 +543,12 @@ class FileDialogButton(py_cui.ui.UIElement):
                 if res is not None:
                     self.command(res)
                 else:
-                    self._parent_dialog.display_warning('No path is selected!')
+                    self._parent_dialog.display_warning("No path is selected!")
             else:
                 self._parent_dialog._root.close_popup()
 
-
     def _draw(self):
-        """Override of base class draw function
-        """
+        """Override of base class draw function"""
 
         super()._draw()
         self._renderer.set_color_mode(self.get_color())
@@ -573,16 +569,13 @@ class InternalFileDialogPopup(py_cui.popups.MessagePopup):
     """
 
     def __init__(self, parent, *args):
-        """Initializer for Internal form Popup
-        """
+        """Initializer for Internal form Popup"""
 
         super().__init__(*args)
         self._parent = parent
 
-
     def _handle_key_press(self, key_pressed):
-        """Override of base class, close in parent instead of root
-        """
+        """Override of base class, close in parent instead of root"""
 
         if key_pressed in self._close_keys:
             self._parent._internal_popup = None
@@ -609,36 +602,49 @@ class FileDialogPopup(py_cui.popups.Popup):
         Currently selected sub-element of file dialog popup
     """
 
-
-    def __init__(self, root, callback, initial_dir, dialog_type, ascii_icons, limit_extensions, color, renderer, logger):
-        """Initalizer for the FileDialogPopup
-        """
+    def __init__(
+        self, root, callback, initial_dir, dialog_type, ascii_icons, limit_extensions, color, renderer, logger
+    ):
+        """Initalizer for the FileDialogPopup"""
 
         # Convert dialog type into popup title message
-        title = ''
-        input_title = 'Path'
-        if dialog_type == 'openfile':
-            title = 'Open File'
-            input_title = 'New File'
-        elif dialog_type == 'opendir':
-            title = 'Open Directory'
-            input_title = 'New Dir'
-        elif dialog_type == 'saveas':
-            title = 'Save As'
-            input_title = 'New Name'
+        title = ""
+        input_title = "Path"
+        if dialog_type == "openfile":
+            title = "Open File"
+            input_title = "New File"
+        elif dialog_type == "opendir":
+            title = "Open Directory"
+            input_title = "New Dir"
+        elif dialog_type == "saveas":
+            title = "Save As"
+            input_title = "New Name"
 
         # Call superclass initailizer
-        py_cui.popups.Popup.__init__(self, root, title, '', color, renderer, logger)
+        py_cui.popups.Popup.__init__(self, root, title, "", color, renderer, logger)
 
         # Our submit action must be a function that takes a string as its only parameter.
         self._submit_action = callback
         self._dialog_type = dialog_type
 
         # Create our internal UI elements. Menu for selection, field for new elements, buttons for submit/cancel.
-        self._filename_input = FileNameInput(self, input_title, '', renderer, logger)
-        self._file_dir_select = FileSelectElement(self, initial_dir, dialog_type, ascii_icons, title, color, None, renderer, logger, limit_extensions=limit_extensions)
-        self._submit_button = FileDialogButton(self, title, self._submit, 1, '', 'OK', renderer, logger)
-        self._cancel_button = FileDialogButton(self, 'Cancel {}'.format(title), self._root.close_popup, 2, '', 'ESC', renderer, logger)
+        self._filename_input = FileNameInput(self, input_title, "", renderer, logger)
+        self._file_dir_select = FileSelectElement(
+            self,
+            initial_dir,
+            dialog_type,
+            ascii_icons,
+            title,
+            color,
+            None,
+            renderer,
+            logger,
+            limit_extensions=limit_extensions,
+        )
+        self._submit_button = FileDialogButton(self, title, self._submit, 1, "", "OK", renderer, logger)
+        self._cancel_button = FileDialogButton(
+            self, f"Cancel {title}", self._root.close_popup, 2, "", "ESC", renderer, logger
+        )
 
         # Internal popup used for secondary errors and warnings
         self._internal_popup = None
@@ -648,14 +654,12 @@ class FileDialogPopup(py_cui.popups.Popup):
         self._file_dir_select.set_selected(True)
         self._currently_selected = self._file_dir_select
 
-
     def _submit(self, output):
         valid, msg = self.output_valid(output)
         if not valid:
             self.display_warning(msg)
         else:
             self._submit_action(output)
-
 
     def display_warning(self, message):
         """Helper function for showing internal popup warning message
@@ -666,29 +670,22 @@ class FileDialogPopup(py_cui.popups.Popup):
             Warning message to display
         """
 
-
-        self._internal_popup = InternalFileDialogPopup(self,
-                                                        self._root,
-                                                        'Warning!',
-                                                        message,
-                                                        py_cui.YELLOW_ON_BLACK,
-                                                        self._renderer,
-                                                        self._logger)
-
+        self._internal_popup = InternalFileDialogPopup(
+            self, self._root, "Warning!", message, py_cui.YELLOW_ON_BLACK, self._renderer, self._logger
+        )
 
     def output_valid(self, output):
-        if self._dialog_type == 'openfile' and not os.path.isfile(output):
-            return False, 'Please select a valid file path!'
-        elif self._dialog_type == 'opendir' and not os.path.isdir(output):
-            return False, 'Please select a valid directory path!'
-        elif self._dialog_type == 'saveas' and not os.access(self._file_dir_select._current_dir, os.W_OK):
-            return False, 'Permission Error!'
+        if self._dialog_type == "openfile" and not os.path.isfile(output):
+            return False, "Please select a valid file path!"
+        elif self._dialog_type == "opendir" and not os.path.isdir(output):
+            return False, "Please select a valid directory path!"
+        elif self._dialog_type == "saveas" and not os.access(self._file_dir_select._current_dir, os.W_OK):
+            return False, "Permission Error!"
         return True, None
-
 
     def get_absolute_start_pos(self):
         """Override of base class, computes position based on root dimensions
-        
+
         Returns
         -------
         start_x, start_y : int
@@ -701,10 +698,9 @@ class FileDialogPopup(py_cui.popups.Popup):
 
         return form_start_x, form_start_y
 
-
     def get_absolute_stop_pos(self):
         """Override of base class, computes position based on root dimensions
-        
+
         Returns
         -------
         stop_x, stop_y : int
@@ -716,7 +712,6 @@ class FileDialogPopup(py_cui.popups.Popup):
         form_stop_y = int(8.75 * root_height / 9)
 
         return form_stop_x, form_stop_y
-
 
     def update_height_width(self):
         """Override of base class function
@@ -732,7 +727,6 @@ class FileDialogPopup(py_cui.popups.Popup):
             self._cancel_button.update_height_width()
         except AttributeError:
             pass
-
 
     def _handle_key_press(self, key_pressed):
         """Override of base class. Here, we handle tabs, enters, and escapes
@@ -776,7 +770,6 @@ class FileDialogPopup(py_cui.popups.Popup):
         else:
             self._internal_popup._handle_key_press(key_pressed)
 
-
     def _handle_mouse_press(self, x, y):
         """Override of base class function
 
@@ -793,21 +786,20 @@ class FileDialogPopup(py_cui.popups.Popup):
             self._filename_input.set_selected(False)
             self._file_dir_select.set_selected(True)
             self._file_dir_select._handle_mouse_press(x, y)
-            
+
         elif self._filename_input._contains_position(x, y):
             self._filename_input.set_selected(True)
             self._file_dir_select.set_selected(False)
             self._filename_input._handle_mouse_press(x, y)
-        
+
         elif self._submit_button._contains_position(x, y):
             self._submit_button._handle_mouse_press(x, y)
         elif self._cancel_button._contains_position(x, y):
             self._cancel_button._handle_mouse_press(x, y)
 
-
     def _draw(self):
         """Override of base class.
-        
+
         Here, we only draw a border, and then the individual form elements
         """
 
@@ -830,4 +822,5 @@ class FileDialogPopup(py_cui.popups.Popup):
             self._internal_popup._draw()
         self._renderer.unset_color_mode(self._color)
 
-#class FileDialogWidget
+
+# class FileDialogWidget

--- a/py_cui/dialogs/form.py
+++ b/py_cui/dialogs/form.py
@@ -7,8 +7,7 @@ import py_cui.popups
 
 
 class DuplicateFormKeyError(Exception):
-    """Error thrown when a duplicate form field key is passed
-    """
+    """Error thrown when a duplicate form field key is passed"""
 
     pass
 
@@ -25,13 +24,11 @@ class FormField(py_cui.ui.TextBoxImplementation):
     """
 
     def __init__(self, fieldname, initial_text, password, required, logger):
-        """Initializer for base FormFields
-        """
+        """Initializer for base FormFields"""
 
         super().__init__(initial_text, password, logger)
         self._fieldname = fieldname
         self._required = required
-
 
     def get_fieldname(self):
         """Getter for field name
@@ -43,7 +40,6 @@ class FormField(py_cui.ui.TextBoxImplementation):
         """
 
         return self._fieldname
-
 
     def is_valid(self):
         """Function that checks if field is valid.
@@ -61,14 +57,13 @@ class FormField(py_cui.ui.TextBoxImplementation):
 
         msg = None
         if len(self._text) == 0 and self.is_required():
-            msg = 'Field <{}> cannot be empty!'.format(self.get_fieldname())
+            msg = f"Field <{self.get_fieldname()}> cannot be empty!"
 
         return msg is None, msg
 
-
     def is_required(self):
         """Checks if field is required
-        
+
         Returns
         -------
         required : bool
@@ -90,19 +85,17 @@ class FormFieldElement(py_cui.ui.UIElement, FormField):
     """
 
     def __init__(self, parent_form, field_index, field, init_text, passwd, required, renderer, logger):
-        """Initializer for the FormFieldElement class
-        """
+        """Initializer for the FormFieldElement class"""
 
         self._parent_form = parent_form
         self._field_index = field_index
         py_cui.ui.UIElement.__init__(self, 0, field, renderer, logger)
         FormField.__init__(self, field, init_text, passwd, required, logger)
-        self._help_text = 'Press Tab to move to the next field, or Enter to submit.'
+        self._help_text = "Press Tab to move to the next field, or Enter to submit."
         self._padx = 0
         self._pady = 0
         self._selected = False
         self.update_height_width()
-
 
     def get_absolute_start_pos(self):
         """Override of base function. Uses the parent element do compute start position
@@ -114,12 +107,13 @@ class FormFieldElement(py_cui.ui.UIElement, FormField):
         """
 
         container_height, _ = self._parent_form.get_absolute_dimensions()
-        single_field_height = int((container_height - 1 - self._parent_form._pady) / self._parent_form.get_num_fields())
+        single_field_height = int(
+            (container_height - 1 - self._parent_form._pady) / self._parent_form.get_num_fields()
+        )
         parent_start_x, parent_start_y = self._parent_form.get_start_position()
-        field_start_x = (parent_start_x + 3 + self._parent_form._padx)
-        field_start_y = (parent_start_y + 1 + self._parent_form._pady + (single_field_height * self._field_index))
+        field_start_x = parent_start_x + 3 + self._parent_form._padx
+        field_start_y = parent_start_y + 1 + self._parent_form._pady + (single_field_height * self._field_index)
         return field_start_x, field_start_y
-
 
     def get_absolute_stop_pos(self):
         """Override of base function. Uses the parent element do compute stop position
@@ -131,33 +125,33 @@ class FormFieldElement(py_cui.ui.UIElement, FormField):
         """
 
         container_height, _ = self._parent_form.get_absolute_dimensions()
-        single_field_height = int((container_height - 1 - self._parent_form._pady) / self._parent_form.get_num_fields())
+        single_field_height = int(
+            (container_height - 1 - self._parent_form._pady) / self._parent_form.get_num_fields()
+        )
         _, parent_start_y = self._parent_form.get_start_position()
         parent_stop_x, _ = self._parent_form.get_stop_position()
-        field_stop_x = (parent_stop_x - 3 - self._parent_form._padx)
-        field_stop_y = (parent_start_y + 1 + self._parent_form._pady + (single_field_height * (self._field_index + 1)) -1)
+        field_stop_x = parent_stop_x - 3 - self._parent_form._padx
+        field_stop_y = (
+            parent_start_y + 1 + self._parent_form._pady + (single_field_height * (self._field_index + 1)) - 1
+        )
         return field_stop_x, field_stop_y
 
-
     def update_height_width(self):
-        """Override of base class. Updates text field variables for form field
-        """
+        """Override of base class. Updates text field variables for form field"""
 
         super().update_height_width()
-        padx, pady              = self.get_padding()
-        start_x, start_y        = self.get_start_position()
-        height, width           = self.get_absolute_dimensions()
-        self._cursor_text_pos   = 0
-        self._cursor_x          = start_x + 2 + padx
-        self._cursor_max_left   = self._cursor_x
-        self._cursor_max_right  = start_x + width - 1 - pady
-        self._cursor_y          = start_y + int(height / 2) + 1
-        self._viewport_width    = self._cursor_max_right - self._cursor_max_left
-
+        padx, pady = self.get_padding()
+        start_x, start_y = self.get_start_position()
+        height, width = self.get_absolute_dimensions()
+        self._cursor_text_pos = 0
+        self._cursor_x = start_x + 2 + padx
+        self._cursor_max_left = self._cursor_x
+        self._cursor_max_right = start_x + width - 1 - pady
+        self._cursor_y = start_y + int(height / 2) + 1
+        self._viewport_width = self._cursor_max_right - self._cursor_max_left
 
     def _handle_key_press(self, key_pressed):
-        """Handles text input for the field. Called by parent
-        """
+        """Handles text input for the field. Called by parent"""
 
         if key_pressed == py_cui.keys.KEY_LEFT_ARROW:
             self._move_left()
@@ -174,24 +168,22 @@ class FormFieldElement(py_cui.ui.UIElement, FormField):
         elif key_pressed > 31 and key_pressed < 128:
             self._insert_char(key_pressed)
 
-
     def _draw(self):
-        """Draw function for the field. Called from parent. Essentially the same as a TextboxPopup
-        """
+        """Draw function for the field. Called from parent. Essentially the same as a TextboxPopup"""
 
         self._renderer.set_color_mode(self._parent_form._color)
         self._renderer.set_color_rules([])
         self._renderer.draw_text(self, self._title, self._cursor_y - 2, bordered=False, selected=self._selected)
         self._renderer.draw_border(self, fill=False, with_title=False)
         render_text = self._text
-        if len(self._text) >self._viewport_width:
+        if len(self._text) > self._viewport_width:
             end = len(self._text) - (self._viewport_width)
             if self._cursor_text_pos < end:
-                render_text = self._text[self._cursor_text_pos:self._cursor_text_pos + (self._viewport_width)]
+                render_text = self._text[self._cursor_text_pos : self._cursor_text_pos + (self._viewport_width)]
             else:
                 render_text = self._text[end:]
         if self._password:
-            temp = '*' * len(render_text)
+            temp = "*" * len(render_text)
             render_text = temp
         self._renderer.draw_text(self, render_text, self._cursor_y, selected=self._selected)
 
@@ -218,16 +210,14 @@ class FormImplementation(py_cui.ui.UIImplementation):
     """
 
     def __init__(self, field_implementations, required_fields, logger):
-        """Initializer for the FormImplemnentation class
-        """
+        """Initializer for the FormImplemnentation class"""
 
         super().__init__(logger)
         self._form_fields = field_implementations
         self._required_fields = required_fields
-        
+
         self._selected_form_index = 0
         self._on_submit_action = None
-
 
     def get_selected_form_index(self):
         """Getter for selected form index
@@ -251,7 +241,6 @@ class FormImplementation(py_cui.ui.UIImplementation):
 
         self._selected_form_index = form_index
 
-
     def set_on_submit_action(self, on_submit_action):
         """Setter for callback on submit
 
@@ -263,16 +252,13 @@ class FormImplementation(py_cui.ui.UIImplementation):
 
         self._on_submit_action = on_submit_action
 
-
     def jump_to_next_field(self):
-        """Function used to jump between form fields
-        """
+        """Function used to jump between form fields"""
 
         if self.get_selected_form_index() < (len(self._form_fields) - 1):
             self.set_selected_form_index(self.get_selected_form_index() + 1)
         else:
             self.set_selected_form_index(0)
-
 
     def is_submission_valid(self):
         """Function that checks if all fields are filled out correctly
@@ -291,7 +277,6 @@ class FormImplementation(py_cui.ui.UIImplementation):
                 return False, err_msg
         return True, None
 
-
     def get(self):
         """Gets values entered into field as a dictionary
 
@@ -308,8 +293,7 @@ class FormImplementation(py_cui.ui.UIImplementation):
 
 
 class Form(py_cui.widgets.Widget, FormImplementation):
-    """Main Widget class extending the FormImplementation. TODO
-    """
+    """Main Widget class extending the FormImplementation. TODO"""
 
     pass
 
@@ -324,16 +308,13 @@ class InternalFormPopup(py_cui.popups.MessagePopup):
     """
 
     def __init__(self, parent, *args):
-        """Initializer for Internal form Popup
-        """
+        """Initializer for Internal form Popup"""
 
         super().__init__(*args)
         self._parent = parent
 
-
     def _handle_key_press(self, key_pressed):
-        """Override of base class, close in parent instead of root
-        """
+        """Override of base class, close in parent instead of root"""
 
         if key_pressed in self._close_keys:
             self._parent._internal_popup = None
@@ -356,28 +337,24 @@ class FormPopup(py_cui.popups.Popup, FormImplementation):
 
         self._num_fields = len(fields)
         if self._num_fields != len(set(fields)):
-            raise DuplicateFormKeyError('PyCUI forms cannot have duplicate fields.')
+            raise DuplicateFormKeyError("PyCUI forms cannot have duplicate fields.")
 
-        py_cui.popups.Popup.__init__(self, root, title, '', color, renderer, logger)
+        py_cui.popups.Popup.__init__(self, root, title, "", color, renderer, logger)
 
         self._form_fields = []
         for i, field in enumerate(fields):
-            init_text = ''
+            init_text = ""
             if field in fields_init_text:
                 init_text = fields_init_text[field]
-            self._form_fields.append(FormFieldElement(self, 
-                                              i, 
-                                              field, 
-                                              init_text, 
-                                              (field in passwd_fields), 
-                                              (field in required_fields), 
-                                              renderer,
-                                              logger))
+            self._form_fields.append(
+                FormFieldElement(
+                    self, i, field, init_text, (field in passwd_fields), (field in required_fields), renderer, logger
+                )
+            )
         self._form_fields[0].set_selected(True)
         FormImplementation.__init__(self, self._form_fields, required_fields, logger)
-        
-        self._internal_popup = None
 
+        self._internal_popup = None
 
     def get_num_fields(self):
         """Getter for number of fields
@@ -390,10 +367,9 @@ class FormPopup(py_cui.popups.Popup, FormImplementation):
 
         return self._num_fields
 
-
     def get_absolute_start_pos(self):
         """Override of base class, computes position based on root dimensions
-        
+
         Returns
         -------
         start_x, start_y : int
@@ -409,17 +385,16 @@ class FormPopup(py_cui.popups.Popup, FormImplementation):
         min_required_y = 4 + (2 * self._pady) + 5 * self._num_fields
         if root_height < min_required_y:
             min_required_y = root_height
-        
+
         form_start_x = int(root_width / 2) - int(min_required_x / 2)
-        
+
         form_start_y = int(root_height / 2) - int(min_required_y / 2)
 
         return form_start_x, form_start_y
 
-
     def get_absolute_stop_pos(self):
         """Override of base class, computes position based on root dimensions
-        
+
         Returns
         -------
         stop_x, stop_y : int
@@ -435,13 +410,12 @@ class FormPopup(py_cui.popups.Popup, FormImplementation):
         min_required_y = 4 + (2 * self._pady) + 5 * self._num_fields
         if root_height < min_required_y:
             min_required_y = root_height
-        
+
         form_stop_x = int(root_width / 2) + int(min_required_x / 2)
-        
+
         form_stop_y = int(root_height / 2) + int(min_required_y / 2)
 
         return form_stop_x, form_stop_y
-
 
     def update_height_width(self):
         """Override of base class function
@@ -455,7 +429,6 @@ class FormPopup(py_cui.popups.Popup, FormImplementation):
                 element.update_height_width()
         except AttributeError:
             pass
-
 
     def _handle_key_press(self, key_pressed):
         """Override of base class. Here, we handle tabs, enters, and escapes
@@ -479,13 +452,15 @@ class FormPopup(py_cui.popups.Popup, FormImplementation):
                     self._root.close_popup()
                     self._on_submit_action(self.get())
                 else:
-                    self._internal_popup = InternalFormPopup(self,
-                                                             self._root, 
-                                                             err_msg, 
-                                                             'Required fields: {}'.format(str(self._required_fields)),
-                                                             py_cui.YELLOW_ON_BLACK, 
-                                                             self._renderer, 
-                                                             self._logger)
+                    self._internal_popup = InternalFormPopup(
+                        self,
+                        self._root,
+                        err_msg,
+                        f"Required fields: {str(self._required_fields)}",
+                        py_cui.YELLOW_ON_BLACK,
+                        self._renderer,
+                        self._logger,
+                    )
             elif key_pressed == py_cui.keys.KEY_ESCAPE:
                 self._root.close_popup()
             else:
@@ -493,7 +468,6 @@ class FormPopup(py_cui.popups.Popup, FormImplementation):
                     self._form_fields[self.get_selected_form_index()]._handle_key_press(key_pressed)
         else:
             self._internal_popup._handle_key_press(key_pressed)
-
 
     def _handle_mouse_press(self, x, y):
         """Override of base class function
@@ -514,10 +488,9 @@ class FormPopup(py_cui.popups.Popup, FormImplementation):
                 self._form_fields[self.get_selected_form_index()].set_selected(True)
                 break
 
-
     def _draw(self):
         """Override of base class.
-        
+
         Here, we only draw a border, and then the individual form elements
         """
 

--- a/py_cui/widget_set.py
+++ b/py_cui/widget_set.py
@@ -32,11 +32,10 @@ class WidgetSet:
     """
 
     def __init__(self, num_rows, num_cols, logger, simulated_terminal=None):
-        """Constructor for WidgetSet
-        """
+        """Constructor for WidgetSet"""
 
-        self._widgets      = {}
-        self._keybindings  = {}
+        self._widgets = {}
+        self._keybindings = {}
 
         self._simulated_terminal = simulated_terminal
 
@@ -45,8 +44,8 @@ class WidgetSet:
             height = term_size.lines
             width = term_size.columns
         else:
-            height  = self._simulated_terminal[0]
-            width   = self._simulated_terminal[1]
+            height = self._simulated_terminal[0]
+            width = self._simulated_terminal[1]
 
         self._height = height
         self._width = width
@@ -56,7 +55,6 @@ class WidgetSet:
 
         self._selected_widget = None
         self._logger = logger
-
 
     def set_selected_widget(self, widget_id):
         """Function that sets the selected cell for the CUI
@@ -70,7 +68,6 @@ class WidgetSet:
         if widget_id in self._widgets.keys():
             self._selected_widget = widget_id
 
-
     def get_widgets(self):
         """Function that gets current set of widgets
 
@@ -81,7 +78,6 @@ class WidgetSet:
         """
 
         return self._widgets
-
 
     def add_key_command(self, key, command):
         """Function that adds a keybinding to the CUI when in overview mode
@@ -96,8 +92,7 @@ class WidgetSet:
 
         self._keybindings[key] = command
 
-
-    def add_scroll_menu(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0):
+    def add_scroll_menu(self, title, row, column, row_span=1, column_span=1, padx=1, pady=0):
         """Function that adds a new scroll menu to the CUI grid
 
         Parameters
@@ -124,24 +119,16 @@ class WidgetSet:
         """
 
         id = len(self.get_widgets().keys())
-        new_scroll_menu     = widgets.ScrollMenu(id,
-                                                 title,
-                                                 self._grid,
-                                                 row,
-                                                 column,
-                                                 row_span,
-                                                 column_span,
-                                                 padx,
-                                                 pady,
-                                                 self._logger)
-        self._widgets[id]  = new_scroll_menu
+        new_scroll_menu = widgets.ScrollMenu(
+            id, title, self._grid, row, column, row_span, column_span, padx, pady, self._logger
+        )
+        self._widgets[id] = new_scroll_menu
         if self._selected_widget is None:
             self.set_selected_widget(id)
-        self._logger.debug(f'Adding widget {title} w/ ID {id} of type {str(type(new_scroll_menu))}')
+        self._logger.debug(f"Adding widget {title} w/ ID {id} of type {str(type(new_scroll_menu))}")
         return new_scroll_menu
 
-
-    def add_checkbox_menu(self, title, row, column, row_span=1, column_span=1, padx=1, pady=0, checked_char='X'):
+    def add_checkbox_menu(self, title, row, column, row_span=1, column_span=1, padx=1, pady=0, checked_char="X"):
         """Function that adds a new checkbox menu to the CUI grid
 
         Parameters
@@ -170,25 +157,18 @@ class WidgetSet:
         """
 
         id = len(self.get_widgets().keys())
-        new_checkbox_menu   = widgets.CheckBoxMenu(id,
-                                                   title,
-                                                   self._grid,
-                                                   row,
-                                                   column,
-                                                   row_span,
-                                                   column_span,
-                                                   padx,
-                                                   pady,
-                                                   self._logger,
-                                                   checked_char)
-        self._widgets[id]  = new_checkbox_menu
+        new_checkbox_menu = widgets.CheckBoxMenu(
+            id, title, self._grid, row, column, row_span, column_span, padx, pady, self._logger, checked_char
+        )
+        self._widgets[id] = new_checkbox_menu
         if self._selected_widget is None:
             self.set_selected_widget(id)
-        self._logger.debug(f'Adding widget {title} w/ ID {id} of type {str(type(new_checkbox_menu))}')
+        self._logger.debug(f"Adding widget {title} w/ ID {id} of type {str(type(new_checkbox_menu))}")
         return new_checkbox_menu
 
-
-    def add_text_box(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0, initial_text = '', password = False):
+    def add_text_box(
+        self, title, row, column, row_span=1, column_span=1, padx=1, pady=0, initial_text="", password=False
+    ):
         """Function that adds a new text box to the CUI grid
 
         Parameters
@@ -219,24 +199,16 @@ class WidgetSet:
         """
 
         id = len(self.get_widgets().keys())
-        new_text_box        = widgets.TextBox(id,
-                                              title,
-                                              self._grid,
-                                              row, column,
-                                              row_span,
-                                              column_span,
-                                              padx, pady,
-                                              self._logger,
-                                              initial_text,
-                                              password)
-        self._widgets[id]    = new_text_box
+        new_text_box = widgets.TextBox(
+            id, title, self._grid, row, column, row_span, column_span, padx, pady, self._logger, initial_text, password
+        )
+        self._widgets[id] = new_text_box
         if self._selected_widget is None:
             self.set_selected_widget(id)
-        self._logger.debug(f'Adding widget {title} w/ ID {id} of type {str(type(new_text_box))}')
+        self._logger.debug(f"Adding widget {title} w/ ID {id} of type {str(type(new_text_box))}")
         return new_text_box
 
-
-    def add_text_block(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0, initial_text = ''):
+    def add_text_block(self, title, row, column, row_span=1, column_span=1, padx=1, pady=0, initial_text=""):
         """Function that adds a new text block to the CUI grid
 
         Parameters
@@ -265,25 +237,16 @@ class WidgetSet:
         """
 
         id = len(self.get_widgets().keys())
-        new_text_block      = widgets.ScrollTextBlock(id,
-                                                      title,
-                                                      self._grid,
-                                                      row,
-                                                      column,
-                                                      row_span,
-                                                      column_span,
-                                                      padx,
-                                                      pady,
-                                                      self._logger,
-                                                      initial_text)
-        self._widgets[id]  = new_text_block
+        new_text_block = widgets.ScrollTextBlock(
+            id, title, self._grid, row, column, row_span, column_span, padx, pady, self._logger, initial_text
+        )
+        self._widgets[id] = new_text_block
         if self._selected_widget is None:
             self.set_selected_widget(id)
-        self._logger.debug(f'Adding widget {title} w/ ID {id} of type {str(type(new_text_block))}')
+        self._logger.debug(f"Adding widget {title} w/ ID {id} of type {str(type(new_text_block))}")
         return new_text_block
 
-
-    def add_label(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0):
+    def add_label(self, title, row, column, row_span=1, column_span=1, padx=1, pady=0):
         """Function that adds a new label to the CUI grid
 
         Parameters
@@ -310,22 +273,13 @@ class WidgetSet:
         """
 
         id = len(self.get_widgets().keys())
-        new_label           = widgets.Label(id,
-                                            title,
-                                            self._grid,
-                                            row,
-                                            column,
-                                            row_span,
-                                            column_span,
-                                            padx,
-                                            pady,
-                                            self._logger)
-        self._widgets[id]  = new_label
-        self._logger.debug(f'Adding widget {title} w/ ID {id} of type {str(type(new_label))}')
+        new_label = widgets.Label(id, title, self._grid, row, column, row_span, column_span, padx, pady, self._logger)
+        self._widgets[id] = new_label
+        self._logger.debug(f"Adding widget {title} w/ ID {id} of type {str(type(new_label))}")
+
         return new_label
 
-
-    def add_block_label(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0, center=True):
+    def add_block_label(self, title, row, column, row_span=1, column_span=1, padx=1, pady=0, center=True):
         """Function that adds a new block label to the CUI grid
 
         Parameters
@@ -354,23 +308,14 @@ class WidgetSet:
         """
 
         id = len(self.get_widgets().keys())
-        new_label           = widgets.BlockLabel(id,
-                                                 title,
-                                                 self._grid,
-                                                 row,
-                                                 column,
-                                                 row_span,
-                                                 column_span,
-                                                 padx,
-                                                 pady,
-                                                 center,
-                                                 self._logger)
-        self._widgets[id]  = new_label
-        self._logger.debug(f'Adding widget {title} w/ ID {id} of type {str(type(new_label))}')
+        new_label = widgets.BlockLabel(
+            id, title, self._grid, row, column, row_span, column_span, padx, pady, center, self._logger
+        )
+        self._widgets[id] = new_label
+        self._logger.debug(f"Adding widget {title} w/ ID {id} of type {str(type(new_label))}")
         return new_label
 
-
-    def add_button(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0, command=None):
+    def add_button(self, title, row, column, row_span=1, column_span=1, padx=1, pady=0, command=None):
         """Function that adds a new button to the CUI grid
 
         Parameters
@@ -399,27 +344,18 @@ class WidgetSet:
         """
 
         id = len(self.get_widgets().keys())
-        new_button          = widgets.Button(id,
-                                             title,
-                                             self._grid,
-                                             row,
-                                             column,
-                                             row_span,
-                                             column_span,
-                                             padx,
-                                             pady,
-                                             self._logger,
-                                             command)
-        self._widgets[id]  = new_button
+        new_button = widgets.Button(
+            id, title, self._grid, row, column, row_span, column_span, padx, pady, self._logger, command
+        )
+        self._widgets[id] = new_button
         if self._selected_widget is None:
             self.set_selected_widget(id)
-        self._logger.debug(f'Adding widget {title} w/ ID {id} of type {str(type(new_button))}')
+        self._logger.debug(f"Adding widget {title} w/ ID {id} of type {str(type(new_button))}")
         return new_button
 
-
-    def add_slider(self, title, row, column, row_span=1,
-                   column_span=1, padx=1, pady=0,
-                   min_val=0, max_val=100, step=1, init_val=0):
+    def add_slider(
+        self, title, row, column, row_span=1, column_span=1, padx=1, pady=0, min_val=0, max_val=100, step=1, init_val=0
+    ):
         """Function that adds a new label to the CUI grid
 
         Parameters
@@ -443,7 +379,7 @@ class WidgetSet:
         max_val = 0 int
             max value of the slider
         step = 0 int
-            step to incremento or decrement
+            step to increment or decrement
         init_val = 0 int
             initial value of the slider
 
@@ -454,21 +390,23 @@ class WidgetSet:
             A reference to the created slider object.
         """
 
-        id = 'Widget{}'.format(len(self._widgets.keys()))
-        new_slider = controls.slider.SliderWidget(id,
-                                                  title,
-                                                  self._grid,
-                                                  row,
-                                                  column,
-                                                  row_span,
-                                                  column_span,
-                                                  padx,
-                                                  pady,
-                                                  self._logger,
-                                                  min_val,
-                                                  max_val,
-                                                  step,
-                                                  init_val)
+        id = f"Widget{len(self._widgets.keys())}"
+        new_slider = controls.slider.SliderWidget(
+            id,
+            title,
+            self._grid,
+            row,
+            column,
+            row_span,
+            column_span,
+            padx,
+            pady,
+            self._logger,
+            min_val,
+            max_val,
+            step,
+            init_val,
+        )
         self._widgets[id] = new_slider
-        self._logger.debug(f'Adding widget {title} w/ ID {id} of type {str(type(new_slider))}')
+        self._logger.debug(f"Adding widget {title} w/ ID {id} of type {str(type(new_slider))}")
         return new_slider

--- a/py_cui/widgets.py
+++ b/py_cui/widgets.py
@@ -50,7 +50,7 @@ class Widget(py_cui.ui.UIElement):
         color rules to load into renderer when drawing widget
     """
 
-    def __init__(self, id, title, grid, row, column, row_span, column_span, padx, pady, logger, selectable = True):
+    def __init__(self, id, title, grid, row, column, row_span, column_span, padx, pady, logger, selectable=True):
         """Initializer for base widget class
 
         Calss UIElement superclass initialzier, and then assigns widget to grid, along with row/column info
@@ -64,21 +64,20 @@ class Widget(py_cui.ui.UIElement):
         self._grid = grid
         grid_rows, grid_cols = self._grid.get_dimensions()
         if (grid_cols < column + column_span) or (grid_rows < row + row_span):
-            raise py_cui.errors.PyCUIOutOfBoundsError("Target grid too small for widget {}".format(title))
+            raise py_cui.errors.PyCUIOutOfBoundsError(f"Target grid too small for widget {title}")
 
-        self._row          = row
-        self._column       = column
-        self._row_span     = row_span
-        self._column_span  = column_span
-        self._padx         = padx
-        self._pady         = pady
-        self._selectable       = selectable
-        self._key_commands     = {}
+        self._row = row
+        self._column = column
+        self._row_span = row_span
+        self._column_span = column_span
+        self._padx = padx
+        self._pady = pady
+        self._selectable = selectable
+        self._key_commands = {}
         self._text_color_rules = []
         self._default_color = py_cui.WHITE_ON_BLACK
         self._border_color = self._default_color
         self.update_height_width()
-
 
     def add_key_command(self, key, command):
         """Maps a keycode to a function that will be executed when in focus mode
@@ -92,7 +91,6 @@ class Widget(py_cui.ui.UIElement):
         """
 
         self._key_commands[key] = command
-
 
     def update_key_command(self, key, command):
         """Maps a keycode to a function that will be executed when in focus mode, if key is already mapped
@@ -108,8 +106,9 @@ class Widget(py_cui.ui.UIElement):
         if key in self._key_commands.keys():
             self.add_key_command(key, command)
 
-
-    def add_text_color_rule(self, regex, color, rule_type, match_type='line', region=[0,1], include_whitespace=False, selected_color=None):
+    def add_text_color_rule(
+        self, regex, color, rule_type, match_type="line", region=[0, 1], include_whitespace=False, selected_color=None
+    ):
         """Forces renderer to draw text using given color if text_condition_function returns True
 
         Parameters
@@ -132,9 +131,10 @@ class Widget(py_cui.ui.UIElement):
         if selected_color is not None:
             selected = selected_color
 
-        new_color_rule = py_cui.colors.ColorRule(regex, color, selected, rule_type, match_type, region, include_whitespace, self._logger)
+        new_color_rule = py_cui.colors.ColorRule(
+            regex, color, selected, rule_type, match_type, region, include_whitespace, self._logger
+        )
         self._text_color_rules.append(new_color_rule)
-
 
     def get_absolute_start_pos(self):
         """Gets the absolute position of the widget in characters. Override of base class function
@@ -145,10 +145,10 @@ class Widget(py_cui.ui.UIElement):
             position of widget in terminal
         """
 
-        x_adjust                = self._column
-        y_adjust                = self._row
-        offset_x, offset_y      = self._grid.get_offsets()
-        row_height, col_width   = self._grid.get_cell_dimensions()
+        x_adjust = self._column
+        y_adjust = self._row
+        offset_x, offset_y = self._grid.get_offsets()
+        row_height, col_width = self._grid.get_cell_dimensions()
 
         if self._column > offset_x:
             x_adjust = offset_x
@@ -160,7 +160,6 @@ class Widget(py_cui.ui.UIElement):
         y_pos = self._row * row_height + 2 + y_adjust
         return x_pos, y_pos
 
-
     def get_absolute_stop_pos(self):
         """Gets the absolute dimensions of the widget in characters. Override of base class function
 
@@ -170,24 +169,23 @@ class Widget(py_cui.ui.UIElement):
             dimensions of widget in terminal
         """
 
-        offset_x, offset_y      = self._grid.get_offsets()
-        row_height, col_width   = self._grid.get_cell_dimensions()
+        offset_x, offset_y = self._grid.get_offsets()
+        row_height, col_width = self._grid.get_cell_dimensions()
 
-        width   = col_width     * self._column_span
-        height  = row_height    * self._row_span
+        width = col_width * self._column_span
+        height = row_height * self._row_span
 
         counter = self._row
         while counter < offset_y and (counter - self._row) < self._row_span:
-            height  = height    + 1
-            counter = counter   + 1
+            height = height + 1
+            counter = counter + 1
 
         counter = self._column
         while counter < offset_x and (counter - self._column) < self._column_span:
-            width   = width     + 1
-            counter = counter   + 1
+            width = width + 1
+            counter = counter + 1
 
         return width + self._start_x, height + self._start_y
-
 
     def get_grid_cell(self):
         """Gets widget row, column in grid
@@ -200,7 +198,6 @@ class Widget(py_cui.ui.UIElement):
 
         return self._row, self._column
 
-
     def get_grid_cell_spans(self):
         """Gets widget row span, column span in grid
 
@@ -211,7 +208,6 @@ class Widget(py_cui.ui.UIElement):
         """
 
         return self._row_span, self._column_span
-
 
     def set_selectable(self, selectable):
         """Setter for widget selectablility
@@ -224,7 +220,6 @@ class Widget(py_cui.ui.UIElement):
 
         self._selectable = selectable
 
-
     def is_selectable(self):
         """Checks if the widget is selectable
 
@@ -235,7 +230,6 @@ class Widget(py_cui.ui.UIElement):
         """
 
         return self._selectable
-
 
     def _is_row_col_inside(self, row, col):
         """Checks if a particular row + column is inside the widget area
@@ -251,17 +245,15 @@ class Widget(py_cui.ui.UIElement):
             True if row, col is within widget bounds, false otherwise
         """
 
-        is_within_rows  = self._row    <= row and row <= (self._row           + self._row_span   - 1)
-        is_within_cols  = self._column <= col and col <= (self._column_span   + self._column     - 1)
+        is_within_rows = self._row <= row and row <= (self._row + self._row_span - 1)
+        is_within_cols = self._column <= col and col <= (self._column_span + self._column - 1)
 
         if is_within_rows and is_within_cols:
             return True
         else:
             return False
 
-
     # BELOW FUNCTIONS SHOULD BE OVERWRITTEN BY SUB-CLASSES
-
 
     def _handle_key_press(self, key_pressed):
         """Base class function that handles all assigned key presses.
@@ -278,7 +270,6 @@ class Widget(py_cui.ui.UIElement):
         if key_pressed in self._key_commands.keys():
             command = self._key_commands[key_pressed]
             command()
-
 
     def _draw(self):
         """Base class draw class that checks if renderer is valid.
@@ -304,20 +295,16 @@ class Label(Widget):
         Toggle for drawing label border
     """
 
-    def __init__(self, id, title,  grid, row, column, row_span, column_span, padx, pady, logger):
-        """Initalizer for Label widget
-        """
+    def __init__(self, id, title, grid, row, column, row_span, column_span, padx, pady, logger):
+        """Initalizer for Label widget"""
 
         super().__init__(id, title, grid, row, column, row_span, column_span, padx, pady, logger, selectable=False)
         self._draw_border = False
 
-
     def toggle_border(self):
-        """Function that gives option to draw border around label
-        """
+        """Function that gives option to draw border around label"""
 
         self._draw_border = not self._draw_border
-
 
     def _draw(self):
         """Override base draw class.
@@ -345,15 +332,13 @@ class BlockLabel(Widget):
         Decides whether or not label should be centered
     """
 
-    def __init__(self, id, title,  grid, row, column, row_span, column_span, padx, pady, center, logger):
-        """Initializer for blocklabel widget
-        """
+    def __init__(self, id, title, grid, row, column, row_span, column_span, padx, pady, center, logger):
+        """Initializer for blocklabel widget"""
 
         super().__init__(id, title, grid, row, column, row_span, column_span, padx, pady, logger, selectable=False)
-        self._lines        = title.splitlines()
-        self._center       = center
-        self._draw_border  = False
-
+        self._lines = title.splitlines()
+        self._center = center
+        self._draw_border = False
 
     def set_title(self, title):
         """Override of base class, splits title into lines for rendering line by line.
@@ -367,13 +352,10 @@ class BlockLabel(Widget):
         self._title = title
         self._lines = title.splitlines()
 
-
     def toggle_border(self):
-        """Function that gives option to draw border around label
-        """
+        """Function that gives option to draw border around label"""
 
         self._draw_border = not self._draw_border
-
 
     def _draw(self):
         """Override base draw class.
@@ -389,23 +371,20 @@ class BlockLabel(Widget):
         for line in self._lines:
             if counter == self._start_y + self._height - self._pady:
                 break
-            self._renderer.draw_text(self, line, counter, centered = self._center, bordered=self._draw_border)
+            self._renderer.draw_text(self, line, counter, centered=self._center, bordered=self._draw_border)
             counter = counter + 1
         self._renderer.unset_color_mode(self._color)
 
 
 class ScrollMenu(Widget, py_cui.ui.MenuImplementation):
-    """A scroll menu widget.
-    """
+    """A scroll menu widget."""
 
     def __init__(self, id, title, grid, row, column, row_span, column_span, padx, pady, logger):
-        """Initializer for scroll menu. calls superclass initializers and sets help text
-        """
+        """Initializer for scroll menu. calls superclass initializers and sets help text"""
 
         Widget.__init__(self, id, title, grid, row, column, row_span, column_span, padx, pady, logger)
         py_cui.ui.MenuImplementation.__init__(self, logger)
-        self.set_help_text('Focus mode on ScrollMenu. Use Up/Down/PgUp/PgDown/Home/End to scroll, Esc to exit.')
-
+        self.set_help_text("Focus mode on ScrollMenu. Use Up/Down/PgUp/PgDown/Home/End to scroll, Esc to exit.")
 
     def _handle_mouse_press(self, x, y):
         """Override of base class function, handles mouse press in menu
@@ -421,7 +400,6 @@ class ScrollMenu(Widget, py_cui.ui.MenuImplementation):
         if viewport_top <= y and viewport_top + len(self._view_items) - self._top_view >= y:
             elem_clicked = y - viewport_top + self._top_view
             self.set_selected_item_index(elem_clicked)
-
 
     def _handle_key_press(self, key_pressed):
         """Override base class function.
@@ -449,10 +427,8 @@ class ScrollMenu(Widget, py_cui.ui.MenuImplementation):
         if key_pressed == py_cui.keys.KEY_PAGE_DOWN:
             self._jump_down(viewport_height)
 
-
     def _draw(self):
-        """Overrides base class draw function
-        """
+        """Overrides base class draw function"""
 
         super()._draw()
         self._renderer.set_color_mode(self._color)
@@ -488,13 +464,13 @@ class CheckBoxMenu(Widget, py_cui.ui.CheckBoxMenuImplementation):
     """
 
     def __init__(self, id, title, grid, row, column, row_span, column_span, padx, pady, logger, checked_char):
-        """Initializer for CheckBoxMenu Widget
-        """
+        """Initializer for CheckBoxMenu Widget"""
 
-        Widget.__init__(self,id, title, grid, row, column, row_span, column_span, padx, pady, logger)
+        Widget.__init__(self, id, title, grid, row, column, row_span, column_span, padx, pady, logger)
         py_cui.ui.CheckBoxMenuImplementation.__init__(self, logger, checked_char)
-        self.set_help_text('Focus mode on CheckBoxMenu. Use up/down to scroll, Enter to toggle set, unset, Esc to exit.')
-
+        self.set_help_text(
+            "Focus mode on CheckBoxMenu. Use up/down to scroll, Enter to toggle set, unset, Esc to exit."
+        )
 
     def _handle_mouse_press(self, x, y):
         """Override of base class function, handles mouse press in menu
@@ -511,7 +487,6 @@ class CheckBoxMenu(Widget, py_cui.ui.CheckBoxMenuImplementation):
             elem_clicked = y - viewport_top + self._top_view
             self.set_selected_item_index(elem_clicked)
             self.mark_item_as_checked(self._view_items[elem_clicked])
-
 
     def _handle_key_press(self, key_pressed):
         """Override of key presses.
@@ -542,10 +517,8 @@ class CheckBoxMenu(Widget, py_cui.ui.CheckBoxMenuImplementation):
         if key_pressed == py_cui.keys.KEY_ENTER:
             self.mark_item_as_checked(self.get())
 
-
     def _draw(self):
-        """Overrides base class draw function
-        """
+        """Overrides base class draw function"""
 
         Widget._draw(self)
         self._renderer.set_color_mode(self._color)
@@ -554,9 +527,9 @@ class CheckBoxMenu(Widget, py_cui.ui.CheckBoxMenuImplementation):
         line_counter = 0
         for item in self._view_items:
             if self._selected_item_dict[item]:
-                line = '[{}] - {}'.format(self._checked_char, str(item))
+                line = f"[{self._checked_char}] - {str(item)}"
             else:
-                line = '[ ] - {}'.format(str(item))
+                line = f"[ ] - {str(item)}"
             if line_counter < self._top_view:
                 line_counter = line_counter + 1
             else:
@@ -572,7 +545,6 @@ class CheckBoxMenu(Widget, py_cui.ui.CheckBoxMenuImplementation):
         self._renderer.reset_cursor(self)
 
 
-
 class Button(Widget):
     """Basic button widget.
 
@@ -585,14 +557,12 @@ class Button(Widget):
     """
 
     def __init__(self, id, title, grid, row, column, row_span, column_span, padx, pady, logger, command):
-        """Initializer for Button Widget
-        """
+        """Initializer for Button Widget"""
 
         super().__init__(id, title, grid, row, column, row_span, column_span, padx, pady, logger)
         self.command = command
         self.set_color(py_cui.MAGENTA_ON_BLACK)
-        self.set_help_text('Focus mode on Button. Press Enter to press button, Esc to exit focus mode.')
-
+        self.set_help_text("Focus mode on Button. Press Enter to press button, Esc to exit focus mode.")
 
     def _handle_key_press(self, key_pressed):
         """Override of base class, adds ENTER listener that runs the button's command
@@ -608,10 +578,8 @@ class Button(Widget):
             if self.command is not None:
                 return self.command()
 
-
     def _draw(self):
-        """Override of base class draw function
-        """
+        """Override of base class draw function"""
 
         super()._draw()
         self._renderer.set_color_mode(self.get_color())
@@ -622,37 +590,33 @@ class Button(Widget):
         self._renderer.unset_color_mode(self.get_color())
 
 
-
 class TextBox(Widget, py_cui.ui.TextBoxImplementation):
-    """Widget for entering small single lines of text
-    """
+    """Widget for entering small single lines of text"""
 
-    def __init__(self, id, title, grid, row, column, row_span, column_span, padx, pady, logger, initial_text, password):
-        """Initializer for TextBox widget. Uses TextBoxImplementation as base
-        """
+    def __init__(
+        self, id, title, grid, row, column, row_span, column_span, padx, pady, logger, initial_text, password
+    ):
+        """Initializer for TextBox widget. Uses TextBoxImplementation as base"""
 
         Widget.__init__(self, id, title, grid, row, column, row_span, column_span, padx, pady, logger)
         py_cui.ui.TextBoxImplementation.__init__(self, initial_text, password, logger)
         self.update_height_width()
-        self.set_help_text('Focus mode on TextBox. Press Esc to exit focus mode.')
-
+        self.set_help_text("Focus mode on TextBox. Press Esc to exit focus mode.")
 
     def update_height_width(self):
-        """Need to update all cursor positions on resize
-        """
+        """Need to update all cursor positions on resize"""
 
         super().update_height_width()
-        padx, _             = self.get_padding()
-        start_x, start_y    = self.get_start_position()
-        height, width       = self.get_absolute_dimensions()
-        self._initial_cursor     = start_x + padx + 2
-        self._cursor_text_pos    = 0
-        self._cursor_x           = start_x + padx + 2
-        self._cursor_max_left    = start_x + padx + 2
-        self._cursor_max_right   = start_x + width - padx - 1
-        self._cursor_y           = start_y + int(height / 2) + 1
-        self._viewport_width     = self._cursor_max_right - self._cursor_max_left
-
+        padx, _ = self.get_padding()
+        start_x, start_y = self.get_start_position()
+        height, width = self.get_absolute_dimensions()
+        self._initial_cursor = start_x + padx + 2
+        self._cursor_text_pos = 0
+        self._cursor_x = start_x + padx + 2
+        self._cursor_max_left = start_x + padx + 2
+        self._cursor_max_right = start_x + width - padx - 1
+        self._cursor_y = start_y + int(height / 2) + 1
+        self._viewport_width = self._cursor_max_right - self._cursor_max_left
 
     def _handle_mouse_press(self, x, y):
         """Override of base class function, handles mouse press in menu
@@ -673,7 +637,6 @@ class TextBox(Widget, py_cui.ui.TextBoxImplementation):
             else:
                 self._cursor_x = self._cursor_max_left + len(self._text)
                 self._cursor_text_pos = len(self._text)
-
 
     def _handle_key_press(self, key_pressed):
         """Override of base handle key press function
@@ -697,14 +660,11 @@ class TextBox(Widget, py_cui.ui.TextBoxImplementation):
             self._jump_to_start()
         elif key_pressed == py_cui.keys.KEY_END:
             self._jump_to_end()
-        elif key_pressed > 31 and key_pressed < 128 or \
-                key_pressed > 1000 and key_pressed < 1128:
+        elif key_pressed > 31 and key_pressed < 128 or key_pressed > 1000 and key_pressed < 1128:
             self._insert_char(key_pressed)
 
-
     def _draw(self):
-        """Override of base draw function
-        """
+        """Override of base draw function"""
 
         super()._draw()
 
@@ -715,11 +675,13 @@ class TextBox(Widget, py_cui.ui.TextBoxImplementation):
         if len(self._text) > self._width - 2 * self._padx - 4:
             end = len(self._text) - (self._width - 2 * self._padx - 4)
             if self._cursor_text_pos < end:
-                render_text = self._text[self._cursor_text_pos:self._cursor_text_pos + (self._width - 2 * self._padx - 4)]
+                render_text = self._text[
+                    self._cursor_text_pos : self._cursor_text_pos + (self._width - 2 * self._padx - 4)
+                ]
             else:
                 render_text = self._text[end:]
         if self._password:
-            temp = '*' * len(render_text)
+            temp = "*" * len(render_text)
             render_text = temp
 
         self._renderer.draw_text(self, render_text, self._cursor_y, selected=self._selected)
@@ -731,37 +693,32 @@ class TextBox(Widget, py_cui.ui.TextBoxImplementation):
 
 
 class ScrollTextBlock(Widget, py_cui.ui.TextBlockImplementation):
-    """Widget for editing large multi-line blocks of text
-    """
+    """Widget for editing large multi-line blocks of text"""
 
     def __init__(self, id, title, grid, row, column, row_span, column_span, padx, pady, logger, initial_text):
-        """Initializer for TextBlock Widget. Uses TextBlockImplementation as base
-        """
+        """Initializer for TextBlock Widget. Uses TextBlockImplementation as base"""
 
         Widget.__init__(self, id, title, grid, row, column, row_span, column_span, padx, pady, logger)
         py_cui.ui.TextBlockImplementation.__init__(self, initial_text, logger)
         self.update_height_width()
-        self.set_help_text('Focus mode on TextBlock. Press Esc to exit focus mode.')
-
+        self.set_help_text("Focus mode on TextBlock. Press Esc to exit focus mode.")
 
     def update_height_width(self):
-        """Function that updates the position of the text and cursor on resize
-        """
+        """Function that updates the position of the text and cursor on resize"""
 
         Widget.update_height_width(self)
-        self._viewport_y_start   = 0
-        self._viewport_x_start   = 0
-        self._cursor_text_pos_x  = 0
-        self._cursor_text_pos_y  = 0
-        self._cursor_y           = self._start_y + 1
-        self._cursor_x           = self._start_x + self._padx + 2
-        self._cursor_max_up      = self._cursor_y
-        self._cursor_max_down    = self._start_y + self._height - self._pady - 2
-        self._cursor_max_left    = self._cursor_x
-        self._cursor_max_right   = self._start_x + self._width - self._padx - 1
-        self._viewport_width     = self._cursor_max_right - self._cursor_max_left
-        self._viewport_height    = self._cursor_max_down  - self._cursor_max_up
-
+        self._viewport_y_start = 0
+        self._viewport_x_start = 0
+        self._cursor_text_pos_x = 0
+        self._cursor_text_pos_y = 0
+        self._cursor_y = self._start_y + 1
+        self._cursor_x = self._start_x + self._padx + 2
+        self._cursor_max_up = self._cursor_y
+        self._cursor_max_down = self._start_y + self._height - self._pady - 2
+        self._cursor_max_left = self._cursor_x
+        self._cursor_max_right = self._start_x + self._width - self._padx - 1
+        self._viewport_width = self._cursor_max_right - self._cursor_max_left
+        self._viewport_height = self._cursor_max_down - self._cursor_max_up
 
     def _handle_mouse_press(self, x, y):
         """Override of base class function, handles mouse press in menu
@@ -784,7 +741,7 @@ class ScrollTextBlock(Widget, py_cui.ui.TextBlockImplementation):
                     self._cursor_text_pos_y = line_clicked_index
                     self._cursor_y = y
                     line = self._text_lines[line_clicked_index]
-                
+
                 if x <= len(line) + self._cursor_max_left:
                     old_text_pos = self._cursor_text_pos_x
                     old_cursor_x = self._cursor_x
@@ -793,7 +750,6 @@ class ScrollTextBlock(Widget, py_cui.ui.TextBlockImplementation):
                 else:
                     self._cursor_x = self._cursor_max_left + len(line)
                     self._cursor_text_pos_x = len(line)
-
 
     def _handle_key_press(self, key_pressed):
         """Override of base class handle key press function
@@ -831,10 +787,8 @@ class ScrollTextBlock(Widget, py_cui.ui.TextBlockImplementation):
         elif key_pressed > 31 and key_pressed < 128:
             self._insert_char(key_pressed)
 
-
     def _draw(self):
-        """Override of base class draw function
-        """
+        """Override of base class draw function"""
 
         super()._draw()
 
@@ -845,12 +799,12 @@ class ScrollTextBlock(Widget, py_cui.ui.TextBlockImplementation):
             if line_counter == len(self._text_lines):
                 break
             render_text = self._text_lines[line_counter]
-            self._renderer.draw_text(self, render_text, counter, start_pos=self._viewport_x_start, selected=self._selected)
+            self._renderer.draw_text(
+                self, render_text, counter, start_pos=self._viewport_x_start, selected=self._selected
+            )
             counter = counter + 1
         if self._selected:
             self._renderer.draw_cursor(self._cursor_y, self._cursor_x)
         else:
             self._renderer.reset_cursor(self)
         self._renderer.unset_color_mode(self._color)
-
-


### PR DESCRIPTION
I converted all appearance of `format()` to `f-string`.
Also reformatted some code to conform to PEP8.


- [✓] I have read the contribution guidelines
- [ / ] CI Unit tests pass (Pytest already raised errors for widgets)
- [✓] New functions/classes have consistent docstrings

**What this pull request changes**

* Conversion to `f-string` implies taht only Python 3.6+ will be supported.  

* Regarding PEP8 format, modifications include:  

1- Unnecessary spaces:  
```diff
- self.todo_scroll_cell =         self.master.add_scroll_menu('TODO',         0, 0, row_span=5, column_span=2)
+ self.todo_scroll_cell = self.master.add_scroll_menu("TODO", 0, 0, row_span=5, column_span=2)
```  
2- Also double quotes instead of singles where recommended.
3- Fit one-liner docstrings on one line:
```diff
- """Read a saved todo file
- """
+ """Read a saved todo file"""
```  
4- Remove spaces around keyword argument assignements:
```diff
- def add_block_label(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0, center=True):
+ def add_block_label(self, title, row, column, row_span=1, column_span=1, padx=1, pady=0, center=True):
```  


**Issues fixed with this pull request**

* Issue #109. Partially, we need to determine if any other 3.6 features integrations would be relevant.

