### PR TITLE
Converted all `.format()` to `f-strings`.

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -86,7 +86,7 @@ class MenuImplementation(UIImplementation):
         if self._selected_item > 0:
             self._selected_item = self._selected_item - 1
 
-        self._logger.debug('Scrolling up to item {}'.format(self._selected_item))
+        self._logger.debug(f'Scrolling up to item {self._selected_item}')
 
     def _scroll_down(self, viewport_height):
         if self._selected_item < len(self._view_items) - 1:
@@ -94,22 +94,22 @@ class MenuImplementation(UIImplementation):
         if self._selected_item > self._top_view + viewport_height:
             self._top_view = self._top_view + 1
 
-        self._logger.debug('Scrolling down to item {}'.format(self._selected_item))
+        self._logger.debug(f'Scrolling down to item {self._selected_item}')
 
     def add_item(self, item_text):
-        self._logger.debug('Adding item {} to menu'.format(item_text))
+        self._logger.debug(f'Adding item {item_text} to menu')
         self._view_items.append(item_text)
 
 
     def add_item_list(self, item_list):
-        self._logger.debug('Adding item list {} to menu'.format(str(item_list)))
+        self._logger.debug(f'Adding item list {str(item_list)} to menu')
         for item in item_list:
             self.add_item(item)
 
     def remove_selected_item(self):
         if len(self._view_items) == 0:
             return
-        self._logger.debug('Removing {}'.format(self._view_items[self._selected_item]))
+        self._logger.debug(f'Removing {self._view_items[self._selected_item]}')
         del self._view_items[self._selected_item]
         if self._selected_item >= len(self._view_items):
             self._selected_item = self._selected_item - 1
@@ -205,7 +205,7 @@ Finally, add a function to the `PyCUI` class in `__init__.py` that will add the 
 ```Python
 def add_scroll_menu(self, title, row, column, row_span = 1, column_span = 1, padx = 1, pady = 0):
 
-    id = 'Widget{}'.format(len(self.get_widgets().keys()))
+    id = f'Widget{len(self.get_widgets().keys())}'
     new_scroll_menu = widgets.ScrollMenu(   id, 
                                             title, 
                                             self._grid, 
@@ -219,7 +219,7 @@ def add_scroll_menu(self, title, row, column, row_span = 1, column_span = 1, pad
     self.get_widgets()[id] = new_scroll_menu
     if self._selected_widget is None:
         self.set_selected_widget(id)
-    self._logger.debug('Adding widget {} w/ ID {} of type {}'.format(title, id, str(type(new_scroll_menu))))
+    self._logger.debug(f'Adding widget {title} w/ ID {id} of type {str(type(new_scroll_menu))}'
     return new_scroll_menu
 ```
 The function must:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -51,7 +51,7 @@ class SimpleTodoList:
     def add_item(self):
         """ Add a todo item """
 
-        self.todo_scroll_cell.add_item('{}'.format(self.new_todo_textbox.get()))
+        self.todo_scroll_cell.add_item(f'{self.new_todo_textbox.get()}')
         self.new_todo_textbox.clear()
 
     def mark_as_in_progress(self):

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -128,7 +128,7 @@ class SimpleTodoList:
     def add_item(self):
         """ Add a todo item """
 
-        self.todo_scroll_cell.add_item('{}'.format(self.new_todo_textbox.get()))
+        self.todo_scroll_cell.add_item(f'{self.new_todo_textbox.get()}')
         self.new_todo_textbox.clear()
 
 

--- a/examples/autogit.py
+++ b/examples/autogit.py
@@ -33,11 +33,11 @@ class AutoGitCUI:
         res = proc.returncode
         if res != 0:
             print(res)
-            print('ERROR - fatal, {} is not a git repository.'.format(self.dir))
+            print(f'ERROR - fatal, {self.dir} is not a git repository.')
             exit()
 
         # Set title
-        self.root.set_title('Autogit v{} - {}'.format(__version__, os.path.basename(self.dir)))
+        self.root.set_title(f'Autogit v{__version__} - {os.path.basename(self.dir)}')
 
         # Keybindings when in overview mode, and set info bar
         self.root.add_key_command(py_cui.keys.KEY_R_LOWER, self.refresh_git_status)
@@ -150,7 +150,7 @@ class AutoGitCUI:
             proc = Popen(['git', 'diff', commit_val], stdout=PIPE, stderr=PIPE)
             out, _ = proc.communicate()
             out = out.decode()
-            self.diff_text_block.set_title('Git Diff for {}'.format(commit_val))
+            self.diff_text_block.set_title(f'Git Diff for {commit_val}')
             self.diff_text_block.set_text(out)
         except:
             self.root.show_warning_popup('Git Failed', 'Unable to read commit diff information')
@@ -205,11 +205,11 @@ class AutoGitCUI:
             _, err = proc.communicate()
             res = proc.returncode
             if res != 0:
-                self.root.show_error_popup('Create Branch Failed Failed', '{}'.format(err))
+                self.root.show_error_popup('Create Branch Failed Failed', f'{err}')
                 return
             self.refresh_git_status(preserve_selected=True)
             self.new_branch_textbox.clear()
-            self.root.show_message_popup('Success', 'Checked out branch {}'.format(new_branch_name))
+            self.root.show_message_popup('Success', f'Checked out branch {new_branch_name}')
         except:
             self.root.show_warning_popup('Git Failed', 'Unable to checkout branch, please check git installation')
 
@@ -228,11 +228,11 @@ class AutoGitCUI:
             _, err = proc.communicate()
             res = proc.returncode
             if res != 0:
-                self.root.show_error_popup('Create Branch Failed Failed', '{}'.format(err))
+                self.root.show_error_popup('Create Branch Failed Failed', f'{err}')
                 return
             self.refresh_git_status(preserve_selected=True)
             self.commit_message_box.clear()
-            self.root.show_message_popup('Success', 'Commited: {}'.format(message))
+            self.root.show_message_popup('Success', f'Commited: {message}')
         else:
             self.root.show_message_popup('Cancelled', 'Commit Operation cancelled')
 
@@ -244,10 +244,10 @@ class AutoGitCUI:
             out, _ = proc.communicate()
             res = proc.returncode
             if res != 0:
-                self.root.show_error_popup('Checkout Failed', '{}'.format(out))
+                self.root.show_error_popup('Checkout Failed', f'{out}')
                 return
             self.refresh_git_status(preserve_selected=True)
-            self.root.show_message_popup('Success', 'Checked out branch {}'.format(target))
+            self.root.show_message_popup('Success', f'Checked out branch {target}')
         except:
             self.root.show_warning_popup('Git Failed', 'Unable to checkout branch, please check git installation')
 
@@ -264,7 +264,7 @@ class AutoGitCUI:
     def open_git_diff(self):
 
         target = self.add_files_menu.get()[3:]
-        self.diff_text_block.title = '{} File Diff'.format(target)
+        self.diff_text_block.title = f'{target} File Diff'
         proc = Popen(['git', 'diff', target], stdout=PIPE, stderr=PIPE)
         out, _ = proc.communicate()
         out = out.decode()
@@ -338,10 +338,10 @@ class AutoGitCUI:
             out, _ = proc.communicate()
             res = proc.returncode
             if res != 0:
-                self.root.show_error_popup('Checkout Failed', '{}'.format(out))
+                self.root.show_error_popup('Checkout Failed', f'{out}')
                 return
             self.refresh_git_status(preserve_selected=True)
-            self.root.show_message_popup('Success', 'Checked out branch {}'.format(target))
+            self.root.show_message_popup('Success', f'Checked out branch {target}')
         except FileNotFoundError:
             self.root.show_warning_popup('Git Failed', 'Unable to checkout branch, please check git installation')
 
@@ -356,10 +356,10 @@ def parse_args():
     if 'directory' not in args.keys():
         return '.' 
     elif not os.path.exists(args['directory']):
-        print('ERROR - {} path does not exist'.format(args['directory']))
+        print(f'ERROR - {args["directory"]} path does not exist')
         exit()
     elif not os.path.isdir(args['directory']):
-        print('ERROR - {} is not a directory'.format(args['directory']))
+        print(f'ERROR - {args["directory"]} is not a directory')
         exit()
     return args['directory']
 

--- a/examples/simple_todo_list.py
+++ b/examples/simple_todo_list.py
@@ -81,7 +81,7 @@ class SimpleTodoList:
         """Add a todo item
         """
 
-        self.todo_scroll_cell.add_item('{}'.format(self.new_todo_textbox.get()))
+        self.todo_scroll_cell.add_item(f'{self.new_todo_textbox.get()}')
 
 
     def remove_item(self):

--- a/examples/snano.py
+++ b/examples/snano.py
@@ -66,10 +66,10 @@ class SuperNano:
         if len(target) == 0:
             target = '.'
         elif not os.path.exists(target):
-            self.root.show_error_popup('Does not exist', 'ERROR - {} path does not exist'.format(target))
+            self.root.show_error_popup('Does not exist', f'ERROR - {target} path does not exist')
             return
         elif not os.path.isdir(target):
-            self.root.show_error_popup('Not a Dir', 'ERROR - {} is not a directory'.format(target))
+            self.root.show_error_popup('Not a Dir', f'ERROR - {target} is not a directory')
             return
         target = os.path.abspath(target)
         self.current_dir_box.set_text(target)
@@ -128,7 +128,7 @@ class SuperNano:
             fp = open(os.path.join(self.dir, self.edit_text_block.get_title()), 'w')
             fp.write(self.edit_text_block.get())
             fp.close()
-            self.root.show_message_popup('Saved', 'Your file has been saved as {}'.format(self.edit_text_block.get_title()))
+            self.root.show_message_popup('Saved', f'Your file has been saved as {self.edit_text_block.get_title()}')
         else:
             self.root.show_error_popup('No File Opened', 'Please open a file before saving it.')
 
@@ -156,10 +156,10 @@ def parse_args():
     if 'directory' not in args.keys():
         return '.' 
     elif not os.path.exists(args['directory']):
-        print('ERROR - {} path does not exist'.format(args['directory']))
+        print(f'ERROR - {args["directory"]} path does not exist')
         exit()
     elif not os.path.isdir(args['directory']):
-        print('ERROR - {} is not a directory'.format(args['directory']))
+        print(f'ERROR - {args["directory"]} is not a directory')
         exit()
     return args['directory']
 
@@ -169,7 +169,7 @@ dir = parse_args()
 
 # Initialize the PyCUI object, and set the title
 root = py_cui.PyCUI(7, 8)
-root.set_title('Super Nano v{}'.format(__version__))
+root.set_title(f'Super Nano v{__version__}')
 
 # Create the wrapper instance object.
 frame = SuperNano(root, dir)

--- a/py_cui/controls/slider.py
+++ b/py_cui/controls/slider.py
@@ -17,8 +17,7 @@ class SliderImplementation(py_cui.ui.UIImplementation):
 
         if self._cur_val < self._min_val or self._cur_val > self._max_val:
             raise py_cui.errors.PyCUIInvalidValue(
-                'initial value must be between {} and {}'
-                .format(self._min_val, self._max_val))
+                f'initial value must be between {self._min_val} and {self._max_val}')
 
 
     def set_bar_char(self, char):
@@ -31,7 +30,7 @@ class SliderImplementation(py_cui.ui.UIImplementation):
             Character to represent progressive bar.
         """
 
-        assert len(char) == 1, "char should contain exactly one character, got {} instead.".format(len(char))
+        assert len(char) == 1, f"char should contain exactly one character, got {len(char)} instead."
         self._bar_char = char
 
 

--- a/py_cui/dialogs/filedialog.py
+++ b/py_cui/dialogs/filedialog.py
@@ -93,9 +93,9 @@ class FileDirElem:
         """
 
         if self._type == 'file':
-            return '{} {}'.format(self._file_icon, self._name)
+            return f'{self._file_icon} {self._name}'
         else:
-            return '{} {}'.format(self._folder_icon, self._name)
+            return f'{self._folder_icon} {self._name}'
 
 
 
@@ -251,7 +251,7 @@ class FileSelectElement(py_cui.ui.UIElement, FileSelectImplementation):
                     self._current_dir = old_dir
                     self.refresh_view()
                 except PermissionError:
-                    self._parent_dialog.display_warning('Permission Error Accessing: {} !'.format(self._current_dir))
+                    self._parent_dialog.display_warning(f'Permission Error Accessing: {self._current_dir} !')
                     self._current_dir = old_dir
                     self.refresh_view()
                 finally:
@@ -638,7 +638,7 @@ class FileDialogPopup(py_cui.popups.Popup):
         self._filename_input = FileNameInput(self, input_title, '', renderer, logger)
         self._file_dir_select = FileSelectElement(self, initial_dir, dialog_type, ascii_icons, title, color, None, renderer, logger, limit_extensions=limit_extensions)
         self._submit_button = FileDialogButton(self, title, self._submit, 1, '', 'OK', renderer, logger)
-        self._cancel_button = FileDialogButton(self, 'Cancel {}'.format(title), self._root.close_popup, 2, '', 'ESC', renderer, logger)
+        self._cancel_button = FileDialogButton(self, f'Cancel {title}', self._root.close_popup, 2, '', 'ESC', renderer, logger)
 
         # Internal popup used for secondary errors and warnings
         self._internal_popup = None

--- a/py_cui/dialogs/form.py
+++ b/py_cui/dialogs/form.py
@@ -61,7 +61,7 @@ class FormField(py_cui.ui.TextBoxImplementation):
 
         msg = None
         if len(self._text) == 0 and self.is_required():
-            msg = 'Field <{}> cannot be empty!'.format(self.get_fieldname())
+            msg = f'Field <{self.get_fieldname()}> cannot be empty!'
 
         return msg is None, msg
 
@@ -482,7 +482,7 @@ class FormPopup(py_cui.popups.Popup, FormImplementation):
                     self._internal_popup = InternalFormPopup(self,
                                                              self._root, 
                                                              err_msg, 
-                                                             'Required fields: {}'.format(str(self._required_fields)),
+                                                             f'Required fields: {str(self._required_fields)}',
                                                              py_cui.YELLOW_ON_BLACK, 
                                                              self._renderer, 
                                                              self._logger)

--- a/py_cui/widget_set.py
+++ b/py_cui/widget_set.py
@@ -454,7 +454,7 @@ class WidgetSet:
             A reference to the created slider object.
         """
 
-        id = 'Widget{}'.format(len(self._widgets.keys()))
+        id = f'Widget{len(self._widgets.keys())}'
         new_slider = controls.slider.SliderWidget(id,
                                                   title,
                                                   self._grid,

--- a/py_cui/widgets.py
+++ b/py_cui/widgets.py
@@ -64,7 +64,7 @@ class Widget(py_cui.ui.UIElement):
         self._grid = grid
         grid_rows, grid_cols = self._grid.get_dimensions()
         if (grid_cols < column + column_span) or (grid_rows < row + row_span):
-            raise py_cui.errors.PyCUIOutOfBoundsError("Target grid too small for widget {}".format(title))
+            raise py_cui.errors.PyCUIOutOfBoundsError(f"Target grid too small for widget {title}")
 
         self._row          = row
         self._column       = column
@@ -554,9 +554,9 @@ class CheckBoxMenu(Widget, py_cui.ui.CheckBoxMenuImplementation):
         line_counter = 0
         for item in self._view_items:
             if self._selected_item_dict[item]:
-                line = '[{}] - {}'.format(self._checked_char, str(item))
+                line = f'[{self._checked_char}] - {str(item)}'
             else:
-                line = '[ ] - {}'.format(str(item))
+                line = f'[ ] - {str(item)}'
             if line_counter < self._top_view:
                 line_counter = line_counter + 1
             else:


### PR DESCRIPTION
I converted all appearance of `.format()` to `f-string`.

- [✓] I have read the contribution guidelines
- [ / ] CI Unit tests pass (Pytest already raised errors for widgets)
- [✓] New functions/classes have consistent docstrings

**What this pull request changes**

* Conversion to `f-string` implies that only Python 3.6+ will be supported.  

**Issues fixed with this pull request**

* Issue #109. Partially, we need to determine if any other 3.6 features integrations would be relevant.

