### PR TITLE
Small modifications to handle exit_key set to None.

### DIFF
--- a/py_cui/__init__.py
+++ b/py_cui/__init__.py
@@ -139,9 +139,14 @@ class PyCUI:
         # Add status and title bar
         self.title_bar = py_cui.statusbar.StatusBar(self._title, BLACK_ON_WHITE)
         exit_key_char = py_cui.keys.get_char_from_ascii(exit_key)
-        self._init_status_bar_text  = f'Press - {exit_key_char} - to exit. Arrow Keys to move ' \
-                                       'between widgets. Enter to enter focus ' \
-                                       'mode.'
+
+        if exit_key_char:
+            self._init_status_bar_text  = f'Press - {exit_key_char} - to exit. Arrow ' \
+                                        'Keys to move between widgets. Enter to ' \
+                                        'enter focus mode.'
+        else:
+            self._init_status_bar_text  = 'Press arrow Keys to move between widgets. ' \
+                                        'Enter to enter focus mode.' \
 
         self.status_bar = py_cui.statusbar.StatusBar(self._init_status_bar_text,
                                                      BLACK_ON_WHITE)

--- a/py_cui/keys.py
+++ b/py_cui/keys.py
@@ -40,7 +40,10 @@ def get_char_from_ascii(key_num):
     char : character
         character converted from ascii
     """
-    
+
+    if key_num is None:
+        return None
+
     return chr(key_num)
 
 


### PR DESCRIPTION
PyCUI main object `exit_key` can now be set to `None`.

**What this pull request changes**

Code modifications are:
- Catching `None` value and returning `None` in `get_char_from_ascii()` function.
- An if-statement in ` __init__.py` to adapt `_init_status_bar_text`  if there is no exit key.

Main draw loop has not been modified and I think this should not be a problem since default "empty" key value is `0` and not `None`.
I did some testing with basic examples and the key integration seems to work as expected.

**Issues fixed with this pull request**

* Issue #115 


