### PR TITLE
Adding fixes for unit tests that were broken by changes to Widget ID …

### DIFF
--- a/tests/test_core/test_py_cui_core.py
+++ b/tests/test_core/test_py_cui_core.py
@@ -29,11 +29,11 @@ def test_add_scroll_menu(PYCUI):
     test_cui.add_scroll_menu('Demo', 1, 1)
     assert len(test_cui.get_widgets().keys()) == 1
     for key in test_cui.get_widgets().keys():
-        assert key == 'Widget0'
+        assert key == 0
         break
-    widget = test_cui.get_widgets()['Widget0']
+    widget = test_cui.get_widgets()[0]
     assert isinstance(widget, py_cui.widgets.ScrollMenu)
-    assert widget.get_id() == 'Widget0'
+    assert widget.get_id() == 0
     row, col = widget.get_grid_cell()
     assert row == 1
     assert col == 1
@@ -44,11 +44,11 @@ def test_add_checkbox_menu(PYCUI):
     test_cui.add_checkbox_menu('Demo', 1, 1)
     assert len(test_cui.get_widgets().keys()) == 1
     for key in test_cui.get_widgets().keys():
-        assert key == 'Widget0'
+        assert key == 0
         break
-    widget = test_cui.get_widgets()['Widget0']
+    widget = test_cui.get_widgets()[0]
     assert isinstance(widget, py_cui.widgets.CheckBoxMenu)
-    assert widget.get_id() == 'Widget0'
+    assert widget.get_id() == 0
     row, col = widget.get_grid_cell()
     assert row == 1
     assert col == 1
@@ -59,11 +59,11 @@ def test_add_label(PYCUI):
     test_cui.add_label('Demo', 1, 1)
     assert len(test_cui.get_widgets().keys()) == 1
     for key in test_cui.get_widgets().keys():
-        assert key == 'Widget0'
+        assert key == 0
         break
-    widget = test_cui.get_widgets()['Widget0']
+    widget = test_cui.get_widgets()[0]
     assert isinstance(widget, py_cui.widgets.Label)
-    assert widget.get_id() == 'Widget0'
+    assert widget.get_id() == 0
     row, col = widget.get_grid_cell()
     assert row == 1
     assert col == 1
@@ -74,11 +74,11 @@ def test_add_block_label(PYCUI):
     test_cui.add_block_label('Demo', 1, 1)
     assert len(test_cui.get_widgets().keys()) == 1
     for key in test_cui.get_widgets().keys():
-        assert key == 'Widget0'
+        assert key == 0
         break
-    widget = test_cui.get_widgets()['Widget0']
+    widget = test_cui.get_widgets()[0]
     assert isinstance(widget, py_cui.widgets.BlockLabel)
-    assert widget.get_id() == 'Widget0'
+    assert widget.get_id() == 0
     row, col = widget.get_grid_cell()
     assert row == 1
     assert col == 1
@@ -89,11 +89,11 @@ def test_add_text_box(PYCUI):
     test_cui.add_text_box('Demo', 1, 1)
     assert len(test_cui.get_widgets().keys()) == 1
     for key in test_cui.get_widgets().keys():
-        assert key == 'Widget0'
+        assert key == 0
         break
-    widget = test_cui.get_widgets()['Widget0']
+    widget = test_cui.get_widgets()[0]
     assert isinstance(widget, py_cui.widgets.TextBox)
-    assert widget.get_id() == 'Widget0'
+    assert widget.get_id() == 0
     row, col = widget.get_grid_cell()
     assert row == 1
     assert col == 1
@@ -104,11 +104,11 @@ def test_add_button(PYCUI):
     test_cui.add_button('Demo', 1, 1)
     assert len(test_cui.get_widgets().keys()) == 1
     for key in test_cui.get_widgets().keys():
-        assert key == 'Widget0'
+        assert key == 0
         break
-    widget = test_cui.get_widgets()['Widget0']
+    widget = test_cui.get_widgets()[0]
     assert isinstance(widget, py_cui.widgets.Button)
-    assert widget.get_id() == 'Widget0'
+    assert widget.get_id() == 0
     row, col = widget.get_grid_cell()
     assert row == 1
     assert col == 1
@@ -119,11 +119,11 @@ def test_add_text_block(PYCUI):
     test_cui.add_text_block('Demo', 1, 1)
     assert len(test_cui.get_widgets().keys()) == 1
     for key in test_cui.get_widgets().keys():
-        assert key == 'Widget0'
+        assert key == 0
         break
-    widget = test_cui.get_widgets()['Widget0']
+    widget = test_cui.get_widgets()[0]
     assert isinstance(widget, py_cui.widgets.ScrollTextBlock)
-    assert widget.get_id() == 'Widget0'
+    assert widget.get_id() == 0
     row, col = widget.get_grid_cell()
     assert row == 1
     assert col == 1

--- a/tests/test_core/test_widget_set.py
+++ b/tests/test_core/test_widget_set.py
@@ -15,11 +15,11 @@ def test_add_scroll_menu(WIDGETSET):
     test_widget_set.add_scroll_menu('Demo', 1, 1)
     assert len(test_widget_set.get_widgets().keys()) == 1
     for key in test_widget_set.get_widgets().keys():
-        assert key == 'Widget0'
+        assert key == 0
         break
-    widget = test_widget_set.get_widgets()['Widget0']
+    widget = test_widget_set.get_widgets()[0]
     assert isinstance(widget, py_cui.widgets.ScrollMenu)
-    assert widget.get_id() == 'Widget0'
+    assert widget.get_id() == 0
     row, col = widget.get_grid_cell()
     assert row == 1
     assert col == 1
@@ -30,11 +30,11 @@ def test_add_checkbox_menu(WIDGETSET):
     test_widget_set.add_checkbox_menu('Demo', 1, 1)
     assert len(test_widget_set.get_widgets().keys()) == 1
     for key in test_widget_set.get_widgets().keys():
-        assert key == 'Widget0'
+        assert key == 0
         break
-    widget = test_widget_set.get_widgets()['Widget0']
+    widget = test_widget_set.get_widgets()[0]
     assert isinstance(widget, py_cui.widgets.CheckBoxMenu)
-    assert widget.get_id() == 'Widget0'
+    assert widget.get_id() == 0
     row, col = widget.get_grid_cell()
     assert row == 1
     assert col == 1
@@ -45,11 +45,11 @@ def test_add_label(WIDGETSET):
     test_widget_set.add_label('Demo', 1, 1)
     assert len(test_widget_set.get_widgets().keys()) == 1
     for key in test_widget_set.get_widgets().keys():
-        assert key == 'Widget0'
+        assert key == 0
         break
-    widget = test_widget_set.get_widgets()['Widget0']
+    widget = test_widget_set.get_widgets()[0]
     assert isinstance(widget, py_cui.widgets.Label)
-    assert widget.get_id() == 'Widget0'
+    assert widget.get_id() == 0
     row, col = widget.get_grid_cell()
     assert row == 1
     assert col == 1
@@ -60,11 +60,11 @@ def test_add_block_label(WIDGETSET):
     test_widget_set.add_block_label('Demo', 1, 1)
     assert len(test_widget_set.get_widgets().keys()) == 1
     for key in test_widget_set.get_widgets().keys():
-        assert key == 'Widget0'
+        assert key == 0
         break
-    widget = test_widget_set.get_widgets()['Widget0']
+    widget = test_widget_set.get_widgets()[0]
     assert isinstance(widget, py_cui.widgets.BlockLabel)
-    assert widget.get_id() == 'Widget0'
+    assert widget.get_id() == 0
     row, col = widget.get_grid_cell()
     assert row == 1
     assert col == 1
@@ -75,11 +75,11 @@ def test_add_text_box(WIDGETSET):
     test_widget_set.add_text_box('Demo', 1, 1)
     assert len(test_widget_set.get_widgets().keys()) == 1
     for key in test_widget_set.get_widgets().keys():
-        assert key == 'Widget0'
+        assert key == 0
         break
-    widget = test_widget_set.get_widgets()['Widget0']
+    widget = test_widget_set.get_widgets()[0]
     assert isinstance(widget, py_cui.widgets.TextBox)
-    assert widget.get_id() == 'Widget0'
+    assert widget.get_id() == 0
     row, col = widget.get_grid_cell()
     assert row == 1
     assert col == 1
@@ -90,11 +90,11 @@ def test_add_button(WIDGETSET):
     test_widget_set.add_button('Demo', 1, 1)
     assert len(test_widget_set.get_widgets().keys()) == 1
     for key in test_widget_set.get_widgets().keys():
-        assert key == 'Widget0'
+        assert key == 0
         break
-    widget = test_widget_set.get_widgets()['Widget0']
+    widget = test_widget_set.get_widgets()[0]
     assert isinstance(widget, py_cui.widgets.Button)
-    assert widget.get_id() == 'Widget0'
+    assert widget.get_id() == 0
     row, col = widget.get_grid_cell()
     assert row == 1
     assert col == 1
@@ -105,11 +105,11 @@ def test_add_text_block(WIDGETSET):
     test_widget_set.add_text_block('Demo', 1, 1)
     assert len(test_widget_set.get_widgets().keys()) == 1
     for key in test_widget_set.get_widgets().keys():
-        assert key == 'Widget0'
+        assert key == 0
         break
-    widget = test_widget_set.get_widgets()['Widget0']
+    widget = test_widget_set.get_widgets()[0]
     assert isinstance(widget, py_cui.widgets.ScrollTextBlock)
-    assert widget.get_id() == 'Widget0'
+    assert widget.get_id() == 0
     row, col = widget.get_grid_cell()
     assert row == 1
     assert col == 1


### PR DESCRIPTION
Quick summary of pull request...

- [X] I have read the contribution guidelines
- [X] CI Unit tests pass
- [X] New functions/classes have consistent docstrings

**What this pull request changes**

* Change widget ID references in unit tests to reflect new ID naming format
