### PR TITLE
Status bars can now be shown/hidden and UI is resized accordingly.

### DIFF
--- a/py_cui/__init__.py
+++ b/py_cui/__init__.py
@@ -130,14 +130,8 @@ class PyCUI:
             height  = simulated_terminal[0]
             width   = simulated_terminal[1]
 
-        # Init terminal height width. Subtract 4 from height
-        # for title/status bar and padding
-        self._height                = height
-        self._width                 = width
-        self._height                = self._height - 4
-
         # Add status and title bar
-        self.title_bar = py_cui.statusbar.StatusBar(self._title, BLACK_ON_WHITE)
+        self.title_bar = py_cui.statusbar.StatusBar(self._title, BLACK_ON_WHITE, root=self, is_title_bar=True)
         exit_key_char = py_cui.keys.get_char_from_ascii(exit_key)
 
         if exit_key_char:
@@ -149,7 +143,13 @@ class PyCUI:
                                         'Enter to enter focus mode.' \
 
         self.status_bar = py_cui.statusbar.StatusBar(self._init_status_bar_text,
-                                                     BLACK_ON_WHITE)
+                                                     BLACK_ON_WHITE, root=self)
+
+        # Init terminal height width. Subtract 4 from height
+        # for title/status bar and padding
+        self._height                = height
+        self._width                 = width
+        self._height                = self._height - self.title_bar.get_height() - self.status_bar.get_height() - 2
 
         # Logging object initialization for py_cui
         self._logger = py_cui.debug._initialize_logger(self,
@@ -268,21 +268,7 @@ class PyCUI:
             self._grid         = new_widget_set._grid
             self._keybindings  = new_widget_set._keybindings
 
-            if self._simulated_terminal is None:
-                if self._stdscr is None:
-                    term_size = shutil.get_terminal_size()
-                    height  = term_size.lines
-                    width   = term_size.columns
-                else:
-                    # Use curses termsize when possible to fix resize bug on windows.
-                    height, width = self._stdscr.getmaxyx()
-            else:
-                height  = self._simulated_terminal[0]
-                width   = self._simulated_terminal[1]
-
-            height  = height - 4
-
-            self._refresh_height_width(height, width)
+            self._refresh_height_width()
             if self._stdscr is not None:
                 self._initialize_widget_renderer()
             self._selected_widget = new_widget_set._selected_widget
@@ -310,7 +296,7 @@ class PyCUI:
         """
 
         # Use current logging object and simulated terminal for sub-widget sets
-        return py_cui.widget_set.WidgetSet(num_rows, num_cols, self._logger, 
+        return py_cui.widget_set.WidgetSet(num_rows, num_cols, self._logger, root=self,
                                             simulated_terminal=self._simulated_terminal)
 
 
@@ -1398,16 +1384,24 @@ class PyCUI:
         self._popup = None
 
 
-    def _refresh_height_width(self, height, width):
-        """Function that updates the height and width of the CUI based on terminal window size
+    def _refresh_height_width(self):
+        """Function that updates the height and width of the CUI based on terminal window size."""
+        
+        if self._simulated_terminal is None:
+            if self._stdscr is None:
+                term_size = shutil.get_terminal_size()
+                height  = term_size.lines
+                width   = term_size.columns
+            else:
+                # Use curses termsize when possible to fix resize bug on windows.
+                height, width = self._stdscr.getmaxyx()
+        else:
+            height  = self._simulated_terminal[0]
+            width   = self._simulated_terminal[1]
 
-        Parameters
-        ----------
-        height : int
-            Window height in terminal characters
-        width : int
-            Window width in terminal characters
-        """
+        height  = height - self.title_bar.get_height() - self.status_bar.get_height() - 2
+        
+        self._logger.debug(f'Resizing CUI to new dimensions {height} by {width}')
 
         self._height = height
         self._width  = width
@@ -1465,12 +1459,12 @@ class PyCUI:
             Window width in terminal characters
         """
 
-        if self.status_bar is not None:
+        if self.status_bar is not None and self.status_bar.get_height() > 0:
             stdscr.attron(curses.color_pair(self.status_bar.get_color()))
             stdscr.addstr(height + 3, 0, fit_text(width, self.status_bar.get_text()))
             stdscr.attroff(curses.color_pair(self.status_bar.get_color()))
 
-        if self.title_bar is not None:
+        if self.title_bar is not None and self.title_bar.get_height() > 0:
             stdscr.attron(curses.color_pair(self.title_bar.get_color()))
             stdscr.addstr(0, 0, fit_text(width, self._title, center=True))
             stdscr.attroff(curses.color_pair(self.title_bar.get_color()))
@@ -1602,14 +1596,6 @@ class PyCUI:
                 # Initialization and size adjustment
                 stdscr.erase()
 
-                # find height width, adjust if status/title bar added. We decrement the height by 4 to account for status/title bar and padding
-                if self._simulated_terminal is None:
-                    height, width   = stdscr.getmaxyx()
-                else:
-                    height = self._simulated_terminal[0]
-                    width  = self._simulated_terminal[1]
-
-                height = height - 4
 
                 # If the user defined an update function to fire on each draw call,
                 # Run it here. This can of course be also handled user-side
@@ -1620,9 +1606,8 @@ class PyCUI:
                 # This is what allows the CUI to be responsive. Adjust grid size based on current terminal size
                 # Resize the grid and the widgets if there was a resize operation
                 if key_pressed == curses.KEY_RESIZE:
-                    self._logger.debug(f'Resizing CUI to new dimensions {height} by {width}')
                     try:
-                        self._refresh_height_width(height, width)
+                        self._refresh_height_width()
                     except py_cui.errors.PyCUIOutOfBoundsError as e:
                         self._logger.info('Resized terminal too small')
                         self._display_window_warning(stdscr, str(e))
@@ -1658,7 +1643,7 @@ class PyCUI:
 
                 try:
                     # Draw status/title bar, and all widgets. Selected widget will be bolded.
-                    self._draw_status_bars(stdscr, height, width)
+                    self._draw_status_bars(stdscr, self._height, self._width)
                     self._draw_widgets()
                     # draw the popup if required
                     if self._popup is not None:

--- a/py_cui/grid.py
+++ b/py_cui/grid.py
@@ -23,6 +23,8 @@ class Grid:
         The number of additional characters found by height mod rows and width mod columns
     _row_height, _column_width : int
         The number of characters in a single grid row, column
+    _title_bar_offset : int
+        Title bar row offset. Defaults to 1. Set to 0 if title bar is hidden.
     _logger : py_cui.debug.PyCUILogger
         logger object for maintaining debug messages
     """
@@ -51,6 +53,7 @@ class Grid:
         self._offset_y      = self._height  % self._num_rows    - 1
         self._row_height    = int(self._height   / self._num_rows)
         self._column_width  = int(self._width    / self._num_columns)
+        self._title_bar_offset = 1
         self._logger        = logger
 
 

--- a/py_cui/statusbar.py
+++ b/py_cui/statusbar.py
@@ -16,19 +16,26 @@ class StatusBar:
         status bar text
     color : py_cui.COLOR
         color to display the statusbar
+    root : py_cui.PyCUI
+        Main PyCUI object reference
+    is_title_bar : bool
+        Is the StatusBar displayed on the top of the grid
     """
 
-    def __init__(self, text, color):
+    def __init__(self, text, color, root, is_title_bar=False):
         """Initializer for statusbar
         """
 
         self.__text = text
         self.__color = color
+        self.__height = 1
+        self.__root = root
+        self.__is_title_bar = is_title_bar
 
 
     def get_color(self):
         """Getter for status bar color
-        
+
         Returns
         -------
         color : int
@@ -39,7 +46,7 @@ class StatusBar:
 
 
     def get_text(self):
-        """Getter for stattus bar text
+        """Getter for status bar text
 
         Returns
         -------
@@ -72,3 +79,33 @@ class StatusBar:
         """
 
         self.__text = text
+
+    def get_height(self):
+        """Getter for status bar height in row
+
+        Returns
+        -------
+        height : int
+            The statusbar height in row
+        """
+
+        return self.__height
+
+    def show(self):
+        """Sets the status bar height to 1"""
+
+        self.__height = 1
+        self._refresh_root_size()
+
+    def hide(self):
+        """Sets the status bar height to 0"""
+
+        self.__height = 0
+        self._refresh_root_size()
+
+    def _refresh_root_size(self):
+        """Resets the grid's title bar offset if needed and calls a UI size update."""
+
+        if self.__is_title_bar:
+            self.__root._grid._title_bar_offset = self.__height
+        self.__root._refresh_height_width()

--- a/py_cui/widget_set.py
+++ b/py_cui/widget_set.py
@@ -29,15 +29,18 @@ class WidgetSet:
         list of keybindings to check against in the main CUI loop
     height, width : int
         height of the terminal in characters, width of terminal in characters
+    root : py_cui.PyCUI
+        Main PyCUI object reference
     """
 
-    def __init__(self, num_rows, num_cols, logger, simulated_terminal=None):
+    def __init__(self, num_rows, num_cols, logger, root, simulated_terminal=None):
         """Constructor for WidgetSet
         """
 
         self._widgets      = {}
         self._keybindings  = {}
 
+        self._root = root
         self._simulated_terminal = simulated_terminal
 
         if self._simulated_terminal is None:
@@ -50,7 +53,8 @@ class WidgetSet:
 
         self._height = height
         self._width = width
-        self._height = self._height - 4
+        status_bars_height = self._root.title_bar.get_height() + self._root.status_bar.get_height()
+        self._height = self._height - status_bars_height - 2
 
         self._grid = grid.Grid(num_rows, num_cols, self._height, self._width, logger)
 

--- a/py_cui/widgets.py
+++ b/py_cui/widgets.py
@@ -1,4 +1,4 @@
-"""Module contatining all core widget classes for py_cui.
+"""Module containing all core widget classes for py_cui.
 
 Widgets are the basic building blocks of a user interface made with py_cui.
 This module contains classes for:
@@ -53,7 +53,7 @@ class Widget(py_cui.ui.UIElement):
     def __init__(self, id, title, grid, row, column, row_span, column_span, padx, pady, logger, selectable = True):
         """Initializer for base widget class
 
-        Calss UIElement superclass initialzier, and then assigns widget to grid, along with row/column info
+        Class UIElement superclass initializer, and then assigns widget to grid, along with row/column info
         and color rules and key commands
         """
 
@@ -156,8 +156,7 @@ class Widget(py_cui.ui.UIElement):
             y_adjust = offset_y
 
         x_pos = self._column * col_width + x_adjust
-        # Always add two to the y_pos, because we have a title bar + a pad row
-        y_pos = self._row * row_height + 2 + y_adjust
+        y_pos = self._row * row_height + y_adjust + self._grid._title_bar_offset + 1
         return x_pos, y_pos
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,7 @@ def PYCUI():
 def WIDGETSET(request, LOGGER):
 
     def _WIDGETSET(rows, cols, height, width):
-        return py_cui.widget_set.WidgetSet(rows, cols, LOGGER, simulated_terminal=[height, width])
+        return py_cui.widget_set.WidgetSet(rows, cols, LOGGER, root=py_cui.PyCUI(rows, cols), simulated_terminal=[height, width])
 
     return _WIDGETSET
 

--- a/tests/test_ui_elements/test_statusbar.py
+++ b/tests/test_ui_elements/test_statusbar.py
@@ -7,7 +7,7 @@ TODO: This test file is probably overkill
 
 
 def test_status_bar():
-    bar = py_cui.statusbar.StatusBar('Hello', py_cui.WHITE_ON_BLACK)
+    bar = py_cui.statusbar.StatusBar('Hello', py_cui.WHITE_ON_BLACK, root=py_cui.PyCUI)
     assert bar.get_text() == 'Hello'
     bar.set_text('Test')
     assert bar.get_text() == 'Test'


### PR DESCRIPTION
Status bars can now be shown/hidden and UI is resized accordingly.

- [ X ] I have read the contribution guidelines
- [ X ] CI Unit tests pass
- [ X ] New functions/classes have consistent docstrings

**What this pull request changes**

`grid.py`, Grid object:
- Now has a `_title_bar_offset` attribute, set to 1 by default and updated to 0 if needed by `StatusBar` methods.

`statusbar.py`, StatusBar object:
- Has 2 new parameters, `root` a reference of main PyCUI object and `is_title_bar`. The later is a bool, default is False,  its purpose is to know if Grid's `_title_bar_offset` needs to be modified or not. This is the simplest way I found to inform the title bar presence within the Grid object.
- Has a `__height` attribute, which is set to 0 or 1.
- Three new methods. `show()` and `hide()` to set its height. And `_refresh_root_size()` to set Grid's `_title_bar_offset` if needed and call PyCUI's `_refresh_height_width()`.

`__init__.py`, PyCui object:
- `_refresh_height_width()` method has been refactored. It was called in two other methods, with height and width calculated and passed as arguments.
As this procedure was repetitive and as I needed to call for a refresh from the `StatusBar` object without redoing all the calculation, I moved height and width setting inside `_refresh_height_width()` method. This method now does not need any argument and can be called as is from anywhere to refresh PyCUI size attributes.
- Two occurences of hard coded `height = height - 4` are now `height = height - self.title_bar.get_height() - self.status_bar.get_height() - 2`.
- `_draw_status_bars()` was previously not drawing only if status bars were `None`, now it also considers their height (> 0).

`widget_set.py`, WidgetSet object:
- Has the `root` parameter too to access status bars.
- Now calculate its height relatively using status bars `get_height()` method.

`widget.py`, Widget object:
- Uses Grid's `_title_bar_offset` in `y_pos` setting.

Some modifications to pytest fixtures and status bar test. To take the new parameters into account.

**Issues fixed with this pull request**

* Issue #114 
* Issue #116 ? As the status bars do not have to be set to `None` anymore ? We could still add some exception handling.

**Optionally, what changes should join this PR**

If the current modifications are merged, we could add some specific tests regarding status bar display and UI resizing.
Also, if we want to implement the top and bottom blank lines padding toggle, as we discussed in #114, it should be a different issue/feature request. It would need some more hard-coded values modifications but I guess using the new PyCUI's `_refresh_height_width()` method it should be easier now.
