### PR TITLE
Remove embedded null character before curses drawing

### DIFF
--- a/py_cui/renderer.py
+++ b/py_cui/renderer.py
@@ -384,6 +384,7 @@ class Renderer:
 
         # Each text elem is a list with [text, color]
         for text_elem in render_text:
+            text_elem[0] = text_elem[0].replace(chr(0), "")
             self.set_color_mode(text_elem[1])
 
             # BLACK_ON_WHITE + BOLD is unreadable on windows terminals


### PR DESCRIPTION
As discussed in #127, a `ValueError` was raised when trying to draw a string containing null characters.

- [x] I have read the contribution guidelines
- [x] CI Unit tests pass
- [x] New functions/classes have consistent docstrings

**What this pull request changes**

Text elements to draw are passed one line at a time.
I added a `.replace()` step, as it is the most efficient built-in function to do this job. The replaced character is `chr(0)` which should work with any type of encoding.

I did some tests with different codecs and they all passed without raising the `ValueError`.

**Issues fixed with this pull request**

* #127 
