### PR TITLE
Fixing #132 - allow for objects in menu popups

### DIFF
--- a/py_cui/popups.py
+++ b/py_cui/popups.py
@@ -416,7 +416,8 @@ class MenuPopup(Popup, py_cui.ui.MenuImplementation):
         self._renderer.set_color_rules([])
         counter = self._pady + 1
         line_counter = 0
-        for line in self._view_items:
+        for item in self._view_items:
+            line = str(item)
             if line_counter < self._top_view:
                 line_counter = line_counter + 1
             else:


### PR DESCRIPTION
Allow for passing in objects into menu popups, like with menu widgets

- [X] I have read the contribution guidelines
- [X] CI Unit tests pass
- [X] New functions/classes have consistent docstrings

**What this pull request changes**

* Menu popup `_draw` function gets the string to draw by calling `str()` on the input item

**Issues fixed with this pull request**

* #132