### PR TITLE
Add a color parameter for message popup and remove default title for …

### DIFF
--- a/docs/popups.md
+++ b/docs/popups.md
@@ -6,13 +6,14 @@ This page contains information regarding all popups supported by `py_cui`. Pleas
 
 **Spawn Command**
 ```
-show_message_popup(title, text)
+show_message_popup(title, text, color = WHITE_ON_BLACK)
 show_warning_popup(title, text)
 show_error_popup(title, text)
 ```
 **Usage**
 
-Used to show a simple message, with a different color depending on warning level.
+`show_message_popup` takes an optional `color` argument which defaults to standard WHITE_ON_BLACK.
+`show_warning_popup` and `show_error_popup` are shorthand for respectively yellow and red colors.
 
 **Keys**
 

--- a/py_cui/__init__.py
+++ b/py_cui/__init__.py
@@ -38,7 +38,6 @@ import py_cui.debug
 import py_cui.errors
 from py_cui.colors import *
 
-
 # Version number
 __version__ = '0.1.4'
 
@@ -1160,7 +1159,7 @@ class PyCUI:
 
     # Popup functions. Used to display messages, warnings, and errors to the user.
 
-    def show_message_popup(self, title: str, text: str) -> None:
+    def show_message_popup(self, title: str, text: str, color: int = WHITE_ON_BLACK) -> None:
         """Shows a message popup
 
         Parameters
@@ -1169,9 +1168,10 @@ class PyCUI:
             Message title
         text : str
             Message text
+        color: int
+            Popup color with format FOREGOUND_ON_BACKGROUND. See colors module. Default: WHITE_ON_BLACK.
         """
 
-        color = WHITE_ON_BLACK
         self._popup = py_cui.popups.MessagePopup(self, title, text, color, self._renderer, self._logger)
         self._logger.debug(f'Opened {str(type(self._popup))} popup with title {title}')
 
@@ -1187,9 +1187,7 @@ class PyCUI:
             Warning text
         """
 
-        color = YELLOW_ON_BLACK
-        self._popup = py_cui.popups.MessagePopup(self, 'WARNING - ' + title, text, color, self._renderer, self._logger)
-        self._logger.debug(f'Opened {str(type(self._popup))} popup with title {title}')
+        self.show_message_popup(title=title, text=text, color=YELLOW_ON_BLACK)
 
 
     def show_error_popup(self, title: str, text: str) -> None:
@@ -1203,9 +1201,7 @@ class PyCUI:
             Error text
         """
 
-        color = RED_ON_BLACK
-        self._popup = py_cui.popups.MessagePopup(self, 'ERROR - ' + title, text, color, self._renderer, self._logger)
-        self._logger.debug(f'Opened {str(type(self._popup))} popup with title {title}')
+        self.show_message_popup(title=title, text=text, color=RED_ON_BLACK)
 
 
     def show_yes_no_popup(self, title: str, command: Callable[[bool], Any]):


### PR DESCRIPTION
Modifications to popups behavior. 
When creating a Warning or an Error popup, `py_cui` added a default "Warning - " or "Error - " to the popup title. This can be annoying if you don't have any useful title to add as you'll be stuck with either "Warning - " with a dash hanging or something like "Warning - Warning".
Also, `show_warning_popup`  and `show_error_popup` are useful methods for quick YELLOW_ON_BLACK and RED_ON_BLACK popups but I think we shouldn't limit color choices for popups to white, yellow and black. So I added an optional `color` parameter which defaults to WHITE_ON_BLACK. 

The only actual change for devs will be the optional `color` argument, which still defaults to previous value hence ensuring backward compatibility.

- [x] I have read the contribution guidelines
- [x] CI Unit tests pass
- [x] New functions/classes have consistent docstrings

**What this pull request changes**

* Remove default  "Warning - "  and "Error -" in popup titles.
* Add an optional `color` parameter to `show_message_popup`.
* Modify doc accordingly.

**Issues fixed with this pull request**

None
