### PR TITLE
Set `_stopped` flag to False on start

### DIFF
--- a/py_cui/__init__.py
+++ b/py_cui/__init__.py
@@ -313,6 +313,7 @@ class PyCUI:
         """
 
         self._logger.info(f'Starting {self._title} CUI')
+        self._stopped = False
         curses.wrapper(self._draw)
 
 


### PR DESCRIPTION
PyCUI `_stopped` flag is now set to False on `start()` method.

- [x] I have read the contribution guidelines
- [x] CI Unit tests pass
- [x] New functions/classes have consistent docstrings

**What this pull request changes**

* `start()` method

**Issues fixed with this pull request**

* #147 
