### PR TITLE
Replace KEY_BACKSPACE by a list

### DIFF
--- a/py_cui/__init__.py
+++ b/py_cui/__init__.py
@@ -113,7 +113,7 @@ class PyCUI:
         """
 
         self._title = 'PyCUI Window'
-        
+
         # When this is not set, the escape character delay
         # is too long for exiting focus mode
         os.environ.setdefault('ESCDELAY', '25')
@@ -211,7 +211,7 @@ class PyCUI:
         self._on_draw_update_func = update_function
 
 
-    def set_widget_cycle_key(self, forward_cycle_key: int=None, reverse_cycle_key: int=None) -> None: 
+    def set_widget_cycle_key(self, forward_cycle_key: int=None, reverse_cycle_key: int=None) -> None:
         """Assigns a key for automatically cycling through widgets in both focus and overview modes
 
         Parameters
@@ -437,12 +437,12 @@ class PyCUI:
         self._logger.debug(f'Set border_characters to {self._border_characters}')
 
 
-    def get_widgets(self) -> Dict[int,Optional['py_cui.widgets.Widget']]:  
+    def get_widgets(self) -> Dict[int,Optional['py_cui.widgets.Widget']]:
         """Function that gets current set of widgets
 
         Returns
         -------
-        widgets : dict of int -> widget 
+        widgets : dict of int -> widget
             dictionary mapping widget IDs to object instances
         """
 
@@ -784,7 +784,7 @@ class PyCUI:
         self._logger.info(f'Adding widget {title} w/ ID {id} of type {str(type(new_button))}')
         return new_button
 
-    
+
     def add_slider(self, title: str, row: int, column: int, row_span: int=1,
                    column_span: int=1, padx: int=1, pady: int=0,
                    min_val: int=0, max_val: int=100, step: int=1, init_val: int=0) -> 'py_cui.controls.slider.SliderWidget':
@@ -850,7 +850,7 @@ class PyCUI:
         ----------
         widget : py_cui.widgets.Widget
             Widget to remove from the UI
-        
+
         Raises
         ------
         TypeError
@@ -865,7 +865,7 @@ class PyCUI:
             raise KeyError(f'Widget with id {widget.get_id()} has already been removed from the UI!')
         else:
             self.get_widgets()[widget.get_id()] = None
-        
+
 
     def get_element_at_position(self, x: int, y: int) -> Optional['py_cui.ui.UIElement']:
         """Returns containing widget for character position
@@ -888,10 +888,10 @@ class PyCUI:
 
         elif self._popup is None:
             for widget_id in self.get_widgets().keys():
-                widget = self.get_widgets()[widget_id] 
+                widget = self.get_widgets()[widget_id]
                 if widget is not None:
                     if widget._contains_position(x, y):
-                        return widget 
+                        return widget
         return None
 
 
@@ -977,7 +977,7 @@ class PyCUI:
         for row in range(row_range_start, row_range_stop):
             for col in range(col_start, col_start + col_span):
                 for widget_id in self.get_widgets().keys():
-                    item_value = self.get_widgets()[widget_id] 
+                    item_value = self.get_widgets()[widget_id]
                     if item_value is not None:
                         if item_value._is_row_col_inside(row, col) and widget_id not in id_list:
                             id_list.append(widget_id)
@@ -1005,7 +1005,7 @@ class PyCUI:
 
         Returns
         -------
-        widget_id : int  
+        widget_id : int
             The widget neighbor ID if found, None otherwise
         """
 
@@ -1048,7 +1048,7 @@ class PyCUI:
 
         Parameters
         ----------
-        widget_id : int 
+        widget_id : int
             the id of the widget to select
         """
 
@@ -1135,8 +1135,8 @@ class PyCUI:
 
             current_widget_id: int = current_widget_num
             next_widget_id: int = next_widget_num
-        current_widget = self.get_widgets()[current_widget_id] 
-        next_widget = self.get_widgets()[next_widget_id] 
+        current_widget = self.get_widgets()[current_widget_id]
+        next_widget = self.get_widgets()[next_widget_id]
         if current_widget and next_widget is not None: #pls check again
             if self._in_focused_mode and cycle_key in current_widget._key_commands.keys():
                 # In the event that we are focusing on a widget with that key defined, we do not cycle.
@@ -1150,8 +1150,8 @@ class PyCUI:
 
         Parameters
         ----------
-        key : py_cui.keys.*
-            The key bound to the command
+        key : py_cui.keys.KEY_*
+            ascii keycode used to map the key
         command : Function
             A no-arg or lambda function to fire on keypress
         """
@@ -1336,14 +1336,14 @@ class PyCUI:
             If not none, fired after loading is completed. Must be a no-arg function
         """
 
-        self._popup = py_cui.dialogs.form.FormPopup(self, 
-                                                    fields, 
-                                                    passwd_fields, 
-                                                    required, 
-                                                    {}, 
-                                                    title, 
-                                                    py_cui.WHITE_ON_BLACK, 
-                                                    self._renderer, 
+        self._popup = py_cui.dialogs.form.FormPopup(self,
+                                                    fields,
+                                                    passwd_fields,
+                                                    required,
+                                                    {},
+                                                    title,
+                                                    py_cui.WHITE_ON_BLACK,
+                                                    self._renderer,
                                                     self._logger)
 
         if callback is not None:
@@ -1372,14 +1372,14 @@ class PyCUI:
             Only show files with extensions in this list if not empty. Default, []
         """
 
-        self._popup = py_cui.dialogs.filedialog.FileDialogPopup(self, 
-                                                                callback, 
-                                                                initial_dir, 
-                                                                popup_type, 
-                                                                ascii_icons, 
-                                                                limit_extensions, 
-                                                                py_cui.WHITE_ON_BLACK, 
-                                                                self._renderer, 
+        self._popup = py_cui.dialogs.filedialog.FileDialogPopup(self,
+                                                                callback,
+                                                                initial_dir,
+                                                                popup_type,
+                                                                ascii_icons,
+                                                                limit_extensions,
+                                                                py_cui.WHITE_ON_BLACK,
+                                                                self._renderer,
                                                                 self._logger)
 
         self._logger.debug(f'Opened {str(type(self._popup))} popup with type {popup_type}')
@@ -1416,7 +1416,7 @@ class PyCUI:
 
     def _refresh_height_width(self) -> None:
         """Function that updates the height and width of the CUI based on terminal window size."""
-        
+
         if self._simulated_terminal is None:
             if self._stdscr is None:
                 term_size = shutil.get_terminal_size()
@@ -1430,7 +1430,7 @@ class PyCUI:
             width   = self._simulated_terminal[1]
 
         height  = height - self.title_bar.get_height() - self.status_bar.get_height() - 2
-        
+
         self._logger.debug(f'Resizing CUI to new dimensions {height} by {width}')
 
         self._height = height
@@ -1464,7 +1464,7 @@ class PyCUI:
 
         for widget_id in self.get_widgets().keys():
             if widget_id != self._selected_widget:
-                widget = self.get_widgets()[widget_id] 
+                widget = self.get_widgets()[widget_id]
                 if widget is not None:
                     widget._draw()
 
@@ -1591,7 +1591,7 @@ class PyCUI:
             self._popup._handle_key_press(key_pressed)
 
 
-    def _draw(self, stdscr) -> None: 
+    def _draw(self, stdscr) -> None:
         """Main CUI draw loop called by start()
 
         Parameters
@@ -1613,7 +1613,7 @@ class PyCUI:
         # Initialization functions. Generates colors and renderer
         self._initialize_colors()
         self._initialize_widget_renderer()
-        
+
         # If user specified a refresh timeout, apply it here
         if self._refresh_timeout > 0:
             self._stdscr.timeout(self._refresh_timeout)
@@ -1651,7 +1651,7 @@ class PyCUI:
                 # Here we handle mouse click events globally, or pass them to the UI element to handle
                 elif key_pressed == curses.KEY_MOUSE:
                     self._logger.info('Detected mouse click')
-                    
+
                     valid_mouse_event = True
                     try:
                         id, x, y, _, mouse_event = curses.getmouse()

--- a/py_cui/__init__.py
+++ b/py_cui/__init__.py
@@ -22,7 +22,7 @@ import logging      # Use logging library for debug purposes
 # there is a open source windows-curses module that adds curses support
 # for python on windows
 import curses
-from typing import Any, Callable, List, Dict, Optional, Tuple
+from typing import Any, Union, Callable, List, Dict, Optional, Tuple
 
 # py_cui imports
 import py_cui
@@ -1145,18 +1145,22 @@ class PyCUI:
                 self.move_focus(next_widget, auto_press_buttons=False)
 
 
-    def add_key_command(self, key: int, command: Callable[[],Any]) -> None:
+    def add_key_command(self, key: Union[int, List[int]], command: Callable[[],Any]) -> None:
         """Function that adds a keybinding to the CUI when in overview mode
 
         Parameters
         ----------
-        key : py_cui.keys.KEY_*
+        key : py_cui.keys.*
             The key bound to the command
         command : Function
             A no-arg or lambda function to fire on keypress
         """
 
-        self._keybindings[key] = command
+        if isinstance(key, list):
+            for value in key:
+                self._keybindings[value] = command
+        else:
+            self._keybindings[key] = command
 
     # Popup functions. Used to display messages, warnings, and errors to the user.
 

--- a/py_cui/dialogs/filedialog.py
+++ b/py_cui/dialogs/filedialog.py
@@ -65,7 +65,7 @@ class FileDirElem:
         # for compatibility reasons.
         if not ascii_icons:
             self._folder_icon = '\U0001f4c1'
-            # Folder icon is two characters, so 
+            # Folder icon is two characters, so
             self._file_icon = '\U0001f5ce' + ' '
         else:
             self._folder_icon = '<DIR>'
@@ -121,7 +121,7 @@ class FileSelectImplementation(py_cui.ui.MenuImplementation):
         """
 
         super().__init__(logger)
-        
+
         self._current_dir = os.path.abspath(initial_loc)
         self._ascii_icons = ascii_icons
         self._dialog_type = dialog_type
@@ -391,7 +391,7 @@ class FileNameInput(py_cui.ui.UIElement, py_cui.ui.TextBoxImplementation):
             self._move_left()
         elif key_pressed == py_cui.keys.KEY_RIGHT_ARROW:
             self._move_right()
-        elif key_pressed == py_cui.keys.KEY_BACKSPACE:
+        elif key_pressed in py_cui.keys.KEYS_BACKSPACE:
             self._erase_char()
         elif key_pressed == py_cui.keys.KEY_DELETE:
             self._delete_char()
@@ -416,7 +416,7 @@ class FileNameInput(py_cui.ui.UIElement, py_cui.ui.TextBoxImplementation):
                     fp = open(new_elem, 'w')
                     fp.close()
                     self._parent_dialog._file_dir_select.refresh_view()
-                    
+
             except FileExistsError:
                 self._parent_dialog.display_warning('File/Directory already exists!')
             except PermissionError:
@@ -510,7 +510,7 @@ class FileDialogButton(py_cui.ui.UIElement):
 
 
     def _handle_mouse_press(self, x: int, y: int, mouse_event: int) -> None:
-        """Handles mouse presses 
+        """Handles mouse presses
 
         Parameters
         ----------
@@ -540,7 +540,7 @@ class FileDialogButton(py_cui.ui.UIElement):
         if key_pressed == py_cui.keys.KEY_ENTER:
             self.perform_command()
 
-    
+
     def perform_command(self) -> None:
         if self.command is not None:
             if self._button_num == 1:
@@ -698,7 +698,7 @@ class FileDialogPopup(py_cui.popups.Popup):
 
     def get_absolute_start_pos(self) -> Tuple[int,int]:
         """Override of base class, computes position based on root dimensions
-        
+
         Returns
         -------
         start_x, start_y : int
@@ -714,7 +714,7 @@ class FileDialogPopup(py_cui.popups.Popup):
 
     def get_absolute_stop_pos(self) -> Tuple[int,int]:
         """Override of base class, computes position based on root dimensions
-        
+
         Returns
         -------
         stop_x, stop_y : int
@@ -803,12 +803,12 @@ class FileDialogPopup(py_cui.popups.Popup):
             self._filename_input.set_selected(False)
             self._file_dir_select.set_selected(True)
             self._file_dir_select._handle_mouse_press(x, y, mouse_event)
-            
+
         elif self._filename_input._contains_position(x, y):
             self._filename_input.set_selected(True)
             self._file_dir_select.set_selected(False)
             self._filename_input._handle_mouse_press(x, y, mouse_event)
-        
+
         elif self._submit_button._contains_position(x, y):
             self._submit_button._handle_mouse_press(x, y, mouse_event)
 
@@ -818,7 +818,7 @@ class FileDialogPopup(py_cui.popups.Popup):
 
     def _draw(self) -> None:
         """Override of base class.
-        
+
         Here, we only draw a border, and then the individual form elements
         """
 

--- a/py_cui/dialogs/filedialog.py
+++ b/py_cui/dialogs/filedialog.py
@@ -391,7 +391,7 @@ class FileNameInput(py_cui.ui.UIElement, py_cui.ui.TextBoxImplementation):
             self._move_left()
         elif key_pressed == py_cui.keys.KEY_RIGHT_ARROW:
             self._move_right()
-        elif key_pressed in py_cui.keys.KEYS_BACKSPACE:
+        elif key_pressed in py_cui.keys.KEY_BACKSPACE:
             self._erase_char()
         elif key_pressed == py_cui.keys.KEY_DELETE:
             self._delete_char()

--- a/py_cui/dialogs/form.py
+++ b/py_cui/dialogs/form.py
@@ -164,7 +164,7 @@ class FormFieldElement(py_cui.ui.UIElement, FormField):
             self._move_left()
         elif key_pressed == py_cui.keys.KEY_RIGHT_ARROW:
             self._move_right()
-        elif key_pressed in py_cui.keys.KEYS_BACKSPACE:
+        elif key_pressed in py_cui.keys.KEY_BACKSPACE:
             self._erase_char()
         elif key_pressed == py_cui.keys.KEY_DELETE:
             self._delete_char()

--- a/py_cui/dialogs/form.py
+++ b/py_cui/dialogs/form.py
@@ -69,7 +69,7 @@ class FormField(py_cui.ui.TextBoxImplementation):
 
     def is_required(self) -> bool:
         """Checks if field is required
-        
+
         Returns
         -------
         required : bool
@@ -164,7 +164,7 @@ class FormFieldElement(py_cui.ui.UIElement, FormField):
             self._move_left()
         elif key_pressed == py_cui.keys.KEY_RIGHT_ARROW:
             self._move_right()
-        elif key_pressed == py_cui.keys.KEY_BACKSPACE:
+        elif key_pressed in py_cui.keys.KEYS_BACKSPACE:
             self._erase_char()
         elif key_pressed == py_cui.keys.KEY_DELETE:
             self._delete_char()
@@ -225,7 +225,7 @@ class FormImplementation(py_cui.ui.UIImplementation):
         super().__init__(logger)
         self._form_fields = field_implementations
         self._required_fields = required_fields
-        
+
         self._selected_form_index = 0
         self._on_submit_action: Optional[Callable[[],Any]] = None
 
@@ -366,17 +366,17 @@ class FormPopup(py_cui.popups.Popup, FormImplementation):
             init_text = ''
             if field in fields_init_text:
                 init_text = fields_init_text[field]
-            self._form_fields.append(FormFieldElement(self, 
-                                              i, 
-                                              field, 
-                                              init_text, 
-                                              (field in passwd_fields), 
-                                              (field in required_fields), 
+            self._form_fields.append(FormFieldElement(self,
+                                              i,
+                                              field,
+                                              init_text,
+                                              (field in passwd_fields),
+                                              (field in required_fields),
                                               renderer,
                                               logger))
         self._form_fields[0].set_selected(True)
         FormImplementation.__init__(self, self._form_fields, required_fields, logger)
-        
+
         self._internal_popup = None
 
 
@@ -394,7 +394,7 @@ class FormPopup(py_cui.popups.Popup, FormImplementation):
 
     def get_absolute_start_pos(self) -> Tuple[int,int]:
         """Override of base class, computes position based on root dimensions
-        
+
         Returns
         -------
         start_x, start_y : int
@@ -410,9 +410,9 @@ class FormPopup(py_cui.popups.Popup, FormImplementation):
         min_required_y = 4 + (2 * self._pady) + 5 * self._num_fields
         if root_height < min_required_y:
             min_required_y = root_height
-        
+
         form_start_x = int(root_width / 2) - int(min_required_x / 2)
-        
+
         form_start_y = int(root_height / 2) - int(min_required_y / 2)
 
         return form_start_x, form_start_y
@@ -420,7 +420,7 @@ class FormPopup(py_cui.popups.Popup, FormImplementation):
 
     def get_absolute_stop_pos(self) -> Tuple[int,int]:
         """Override of base class, computes position based on root dimensions
-        
+
         Returns
         -------
         stop_x, stop_y : int
@@ -436,9 +436,9 @@ class FormPopup(py_cui.popups.Popup, FormImplementation):
         min_required_y = 4 + (2 * self._pady) + 5 * self._num_fields
         if root_height < min_required_y:
             min_required_y = root_height
-        
+
         form_stop_x = int(root_width / 2) + int(min_required_x / 2)
-        
+
         form_stop_y = int(root_height / 2) + int(min_required_y / 2)
 
         return form_stop_x, form_stop_y
@@ -479,14 +479,14 @@ class FormPopup(py_cui.popups.Popup, FormImplementation):
                 if valid:
                     self._root.close_popup()
                     if self._on_submit_action is not None:
-                        self._on_submit_action(self.get()) 
+                        self._on_submit_action(self.get())
                 else:
                     self._internal_popup = InternalFormPopup(self,
-                                                             self._root, 
-                                                             err_msg, 
+                                                             self._root,
+                                                             err_msg,
                                                              f'Required fields: {str(self._required_fields)}',
-                                                             py_cui.YELLOW_ON_BLACK, 
-                                                             self._renderer, 
+                                                             py_cui.YELLOW_ON_BLACK,
+                                                             self._renderer,
                                                              self._logger)
             elif key_pressed == py_cui.keys.KEY_ESCAPE:
                 self._root.close_popup()
@@ -519,7 +519,7 @@ class FormPopup(py_cui.popups.Popup, FormImplementation):
 
     def _draw(self) -> None:
         """Override of base class.
-        
+
         Here, we only draw a border, and then the individual form elements
         """
 

--- a/py_cui/keys.py
+++ b/py_cui/keys.py
@@ -56,9 +56,9 @@ KEY_SPACE       = get_ascii_from_char(' ')
 KEY_DELETE      = curses.KEY_DC
 KEY_TAB         = get_ascii_from_char('\t')
 
-KEYS_BACKSPACE = [8, 127, curses.KEY_BACKSPACE]
+KEY_BACKSPACE = [8, 127, curses.KEY_BACKSPACE]
 
-SPECIAL_KEYS = [KEY_ENTER, KEY_ESCAPE, KEY_SPACE, KEY_DELETE, KEY_TAB] + KEYS_BACKSPACE
+SPECIAL_KEYS = [KEY_ENTER, KEY_ESCAPE, KEY_SPACE, KEY_DELETE, KEY_TAB] + KEY_BACKSPACE
 
 # Page navigation keys
 KEY_PAGE_UP     = curses.KEY_PPAGE

--- a/py_cui/keys.py
+++ b/py_cui/keys.py
@@ -18,7 +18,7 @@ def get_ascii_from_char(char: str) -> int:
     ----------
     char : character
         character to convert to ascii
-    
+
     Returns
     -------
     ascii_code : int
@@ -56,17 +56,9 @@ KEY_SPACE       = get_ascii_from_char(' ')
 KEY_DELETE      = curses.KEY_DC
 KEY_TAB         = get_ascii_from_char('\t')
 
-# Pressing backspace returns 8 on windows?
-if platform == 'win32':
-    KEY_BACKSPACE   = 8
-# Adds support for 'delete/backspace' key on OSX
-elif platform == 'darwin':
-    KEY_BACKSPACE   = 127
-else:
-    KEY_BACKSPACE   = curses.KEY_BACKSPACE
+KEYS_BACKSPACE = [8, 127, curses.KEY_BACKSPACE]
 
-SPECIAL_KEYS = [KEY_ENTER, KEY_ESCAPE, KEY_SPACE, KEY_DELETE, KEY_TAB, KEY_BACKSPACE]
-
+SPECIAL_KEYS = [KEY_ENTER, KEY_ESCAPE, KEY_SPACE, KEY_DELETE, KEY_TAB] + KEYS_BACKSPACE
 
 # Page navigation keys
 KEY_PAGE_UP     = curses.KEY_PPAGE
@@ -85,13 +77,13 @@ ARROW_KEYS = [KEY_UP_ARROW, KEY_DOWN_ARROW, KEY_LEFT_ARROW, KEY_RIGHT_ARROW]
 
 
 if platform == 'linux' or platform == 'darwin':
-    
+
     # Modified arrow keys
     KEY_SHIFT_LEFT  = 393
     KEY_SHIFT_RIGHT = 402
     KEY_SHIFT_UP    = 337
     KEY_SHIFT_DOWN  = 336
-    
+
     KEY_CTRL_LEFT   = 560
     KEY_CTRL_RIGHT  = 545
     KEY_CTRL_UP     = 566
@@ -103,7 +95,7 @@ elif platform == 'win32':
     KEY_SHIFT_RIGHT = 400
     KEY_SHIFT_UP    = 547
     KEY_SHIFT_DOWN  = 548
-    
+
     KEY_CTRL_LEFT   = 443
     KEY_CTRL_RIGHT  = 444
     KEY_CTRL_UP     = 480

--- a/py_cui/popups.py
+++ b/py_cui/popups.py
@@ -49,7 +49,7 @@ class Popup(py_cui.ui.UIElement):
         self._selected_color        = color
         self.update_height_width()
 
-    
+
     def _increment_counter(self):
         """Function that increments an internal counter
         """
@@ -71,7 +71,7 @@ class Popup(py_cui.ui.UIElement):
 
     def get_absolute_start_pos(self) -> Tuple[int,int]:
         """Override of base class, computes position based on root dimensions
-        
+
         Returns
         -------
         start_x, start_y : int
@@ -84,7 +84,7 @@ class Popup(py_cui.ui.UIElement):
 
     def get_absolute_stop_pos(self) -> Tuple[int,int]:
         """Override of base class, computes position based on root dimensions
-        
+
         Returns
         -------
         stop_x, stop_y : int
@@ -138,11 +138,10 @@ class MessagePopup(Popup):
         """
 
         super().__init__(root, title, text, color, renderer, logger)
-        self._close_keys = [ py_cui.keys.KEY_ENTER, 
-                            py_cui.keys.KEY_ESCAPE, 
-                            py_cui.keys.KEY_SPACE, 
-                            py_cui.keys.KEY_BACKSPACE, 
-                            py_cui.keys.KEY_DELETE]
+        self._close_keys = [ py_cui.keys.KEY_ENTER,
+                            py_cui.keys.KEY_ESCAPE,
+                            py_cui.keys.KEY_SPACE,
+                            py_cui.keys.KEY_DELETE] + py_cui.keys.KEYS_BACKSPACE
 
 
     def _draw(self) -> None:
@@ -284,7 +283,7 @@ class TextBoxPopup(Popup, py_cui.ui.TextBoxImplementation):
             self._move_left()
         elif key_pressed == py_cui.keys.KEY_RIGHT_ARROW:
             self._move_right()
-        elif key_pressed == py_cui.keys.KEY_BACKSPACE:
+        elif key_pressed in py_cui.keys.KEYS_BACKSPACE:
             self._erase_char()
         elif key_pressed == py_cui.keys.KEY_DELETE:
             self._delete_char()
@@ -481,7 +480,7 @@ class LoadingIconPopup(Popup):
         self._icon_counter = self._icon_counter + 1
         if self._icon_counter == len(self._loading_icons):
             self._icon_counter = 0
-        
+
         # Use Superclass draw after new text is computed
         super()._draw()
 
@@ -554,6 +553,6 @@ class LoadingBarPopup(Popup):
 
         self.set_text(f'{"#" * completed_blocks}{"-" * non_completed_blocks} \
                        ({self._completed_items}/{self._num_items}) {self._loading_icons[self._icon_counter]}')
-        
+
         # Use Superclass draw after new text is computed
         super()._draw()

--- a/py_cui/popups.py
+++ b/py_cui/popups.py
@@ -141,7 +141,7 @@ class MessagePopup(Popup):
         self._close_keys = [ py_cui.keys.KEY_ENTER,
                             py_cui.keys.KEY_ESCAPE,
                             py_cui.keys.KEY_SPACE,
-                            py_cui.keys.KEY_DELETE] + py_cui.keys.KEYS_BACKSPACE
+                            py_cui.keys.KEY_DELETE] + py_cui.keys.KEY_BACKSPACE
 
 
     def _draw(self) -> None:
@@ -283,7 +283,7 @@ class TextBoxPopup(Popup, py_cui.ui.TextBoxImplementation):
             self._move_left()
         elif key_pressed == py_cui.keys.KEY_RIGHT_ARROW:
             self._move_right()
-        elif key_pressed in py_cui.keys.KEYS_BACKSPACE:
+        elif key_pressed in py_cui.keys.KEY_BACKSPACE:
             self._erase_char()
         elif key_pressed == py_cui.keys.KEY_DELETE:
             self._delete_char()

--- a/py_cui/widget_set.py
+++ b/py_cui/widget_set.py
@@ -9,7 +9,7 @@ It can be used to swap between collections of widgets (screens) in a py_cui
 # TODO: Should create an initial widget set in PyCUI class that widgets are added to by default.
 
 import shutil
-from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Union, Callable, Dict, List, Optional, TYPE_CHECKING
 import py_cui.widgets as widgets
 import py_cui.grid as grid
 import py_cui.controls as controls
@@ -91,7 +91,7 @@ class WidgetSet:
         return self._widgets
 
 
-    def add_key_command(self, key: int, command: Callable[[],Any]):
+    def add_key_command(self, key: Union[int, List[int]], command: Callable[[],Any]) -> None:
         """Function that adds a keybinding to the CUI when in overview mode
 
         Parameters
@@ -102,7 +102,11 @@ class WidgetSet:
             A no-arg or lambda function to fire on keypress
         """
 
-        self._keybindings[key] = command
+        if isinstance(key, list):
+            for value in key:
+                self._keybindings[value] = command
+        else:
+            self._keybindings[key] = command
 
 
     def add_scroll_menu(self, title: str, row: int, column: int, row_span: int = 1, column_span: int = 1, padx: int = 1, pady: int = 0) -> 'py_cui.widgets.ScrollMenu':
@@ -427,9 +431,9 @@ class WidgetSet:
 
     def add_slider(self, title: str, row: int, column: int, row_span: int=1,
                    column_span: int=1, padx: int=1, pady: int=0,
-                   min_val: int=0, max_val: int=100, step: int=1, init_val: int=0) -> 'py_cui.controls.slider.SliderWidget':     
-                   
-                   
+                   min_val: int=0, max_val: int=100, step: int=1, init_val: int=0) -> 'py_cui.controls.slider.SliderWidget':
+
+
         """Function that adds a new label to the CUI grid
 
         Parameters

--- a/py_cui/widget_set.py
+++ b/py_cui/widget_set.py
@@ -97,7 +97,7 @@ class WidgetSet:
         Parameters
         ----------
         key : py_cui.keys.KEY_*
-            The key bound to the command
+            ascii keycode used to map the key
         command : Function
             A no-arg or lambda function to fire on keypress
         """

--- a/py_cui/widgets.py
+++ b/py_cui/widgets.py
@@ -28,7 +28,7 @@ import py_cui.ui
 import py_cui.colors
 import py_cui.errors
 
-from typing import Callable, List, Dict, Tuple, Any, Optional
+from typing import Union, Callable, List, Dict, Tuple, Any, Optional
 
 
 class Widget(py_cui.ui.UIElement):
@@ -84,18 +84,22 @@ class Widget(py_cui.ui.UIElement):
         self.update_height_width()
 
 
-    def add_key_command(self, key: int, command: Callable[[],Any]) -> Any:
-        """Maps a keycode to a function that will be executed when in focus mode
+    def add_key_command(self, key: Union[int, List[int]], command: Callable[[],Any]) -> None:
+        """Function that adds a keybinding to the CUI when in overview mode
 
         Parameters
-        ----------
-        key : py_cui.keys.KEY
+        ----------c
+        key : py_cui.keys.*
             ascii keycode used to map the key
         command : function without args
             a non-argument function or lambda function to execute if in focus mode and key is pressed
         """
 
-        self._key_commands[key] = command
+        if isinstance(key, list):
+            for value in key:
+                self._keybindings[value] = command
+        else:
+            self._keybindings[key] = command
 
 
     def add_mouse_command(self, mouse_event: int, command: Callable[[],Any]) -> None:
@@ -123,12 +127,12 @@ class Widget(py_cui.ui.UIElement):
         self._mouse_commands[mouse_event] = command
 
 
-    def update_key_command(self, key: int, command: Callable[[],Any]) -> Any:
+    def update_key_command(self, key: Union[int, List[int]], command: Callable[[],Any]) -> Any:
         """Maps a keycode to a function that will be executed when in focus mode, if key is already mapped
 
         Parameters
         ----------
-        key : py_cui.keys.KEY
+        key : py_cui.keys.KEY_*
             ascii keycode used to map the key
         command : function without args
             a non-argument function or lambda function to execute if in focus mode and key is pressed

--- a/py_cui/widgets.py
+++ b/py_cui/widgets.py
@@ -306,7 +306,7 @@ class Widget(py_cui.ui.UIElement):
         # Retrieve the command function if it exists
         if mouse_event in self._mouse_commands.keys():
             command = self._mouse_commands[mouse_event]
-            
+
             # Identify num of args from callable. This allows for user to create commands that take in x, y
             # coords of the mouse press as input
             num_args = 0
@@ -486,7 +486,7 @@ class ScrollMenu(Widget, py_cui.ui.MenuImplementation):
             if viewport_top <= y and viewport_top + len(self._view_items) - self._top_view >= y:
                 elem_clicked = y - viewport_top + self._top_view
                 self.set_selected_item_index(elem_clicked)
-        
+
             if self.get_selected_item_index() != current and self._on_selection_change is not None:
                 self._process_selection_change_event()
 
@@ -511,7 +511,7 @@ class ScrollMenu(Widget, py_cui.ui.MenuImplementation):
 
         current = self.get_selected_item_index()
         viewport_height = self.get_viewport_height()
-        
+
         if key_pressed == py_cui.keys.KEY_UP_ARROW:
             self._scroll_up()
         if key_pressed == py_cui.keys.KEY_DOWN_ARROW:
@@ -671,7 +671,7 @@ class Button(Widget):
         self.command = command
         self.set_color(py_cui.MAGENTA_ON_BLACK)
         self.set_help_text('Focus mode on Button. Press Enter to press button, Esc to exit focus mode.')
-        
+
         # By default we will process command on click or double click
         if self.command is not None:
             self.add_mouse_command(py_cui.keys.LEFT_MOUSE_CLICK, self.command)
@@ -773,7 +773,7 @@ class TextBox(Widget, py_cui.ui.TextBoxImplementation):
             self._move_left()
         elif key_pressed == py_cui.keys.KEY_RIGHT_ARROW:
             self._move_right()
-        elif key_pressed == py_cui.keys.KEY_BACKSPACE:
+        elif key_pressed in py_cui.keys.KEYS_BACKSPACE:
             self._erase_char()
         elif key_pressed == py_cui.keys.KEY_DELETE:
             self._delete_char()
@@ -857,7 +857,7 @@ class ScrollTextBlock(Widget, py_cui.ui.TextBlockImplementation):
         """
 
         Widget._handle_mouse_press(self, x, y, mouse_event)
-        
+
         if mouse_event == py_cui.keys.LEFT_MOUSE_CLICK:
             if y >= self._cursor_max_up and y <= self._cursor_max_down:
                 if x >= self._cursor_max_left and x <= self._cursor_max_right:
@@ -901,7 +901,7 @@ class ScrollTextBlock(Widget, py_cui.ui.TextBlockImplementation):
         # TODO: Fix this janky operation here
         elif key_pressed == py_cui.keys.KEY_DOWN_ARROW and self._cursor_text_pos_y < len(self._text_lines) - 1:
             self._move_down()
-        elif key_pressed == py_cui.keys.KEY_BACKSPACE:
+        elif key_pressed in py_cui.keys.KEYS_BACKSPACE:
             self._handle_backspace()
         elif key_pressed == py_cui.keys.KEY_DELETE:
             self._handle_delete()

--- a/py_cui/widgets.py
+++ b/py_cui/widgets.py
@@ -85,11 +85,11 @@ class Widget(py_cui.ui.UIElement):
 
 
     def add_key_command(self, key: Union[int, List[int]], command: Callable[[],Any]) -> None:
-        """Function that adds a keybinding to the CUI when in overview mode
+        """Maps a keycode to a function that will be executed when in focus mode
 
         Parameters
-        ----------c
-        key : py_cui.keys.*
+        ----------
+        key : py_cui.keys.KEY_*
             ascii keycode used to map the key
         command : function without args
             a non-argument function or lambda function to execute if in focus mode and key is pressed

--- a/py_cui/widgets.py
+++ b/py_cui/widgets.py
@@ -773,7 +773,7 @@ class TextBox(Widget, py_cui.ui.TextBoxImplementation):
             self._move_left()
         elif key_pressed == py_cui.keys.KEY_RIGHT_ARROW:
             self._move_right()
-        elif key_pressed in py_cui.keys.KEYS_BACKSPACE:
+        elif key_pressed in py_cui.keys.KEY_BACKSPACE:
             self._erase_char()
         elif key_pressed == py_cui.keys.KEY_DELETE:
             self._delete_char()
@@ -901,7 +901,7 @@ class ScrollTextBlock(Widget, py_cui.ui.TextBlockImplementation):
         # TODO: Fix this janky operation here
         elif key_pressed == py_cui.keys.KEY_DOWN_ARROW and self._cursor_text_pos_y < len(self._text_lines) - 1:
             self._move_down()
-        elif key_pressed in py_cui.keys.KEYS_BACKSPACE:
+        elif key_pressed in py_cui.keys.KEY_BACKSPACE:
             self._handle_backspace()
         elif key_pressed == py_cui.keys.KEY_DELETE:
             self._handle_delete()


### PR DESCRIPTION
This PR tries to solve #74.
Currently the `KEY_BACKSPACE` var is set either explicitly if win32 or darwin, or else by curses.
The thing is curses might get a wrong backspace key on Linux depending on `$TERM` environment variable value and actual terminal conf.

To solve this issue, we might just catch as a backspace all possible values. Either `8` (ASCII BS), `127` (ASCII DEL) and any other value returned by `curses.KEY_BACKSPACE`.  
This shouldn't cause any false positive as `8` and `127` are well defined, except if a user explicitly tweaked his terminal configuration for  `8` and `127` which would cause trouble with curses anyway. 

- [x] I have read the contribution guidelines
- [x] CI Unit tests pass
- [x] New functions/classes have consistent docstrings

**What this pull request changes**

- `KEY_BACKSPACE` is now a list `KEYS_BACKSPACE`.
- And some auto deletion of useless white spaces, well, better now than never.

**Issues fixed with this pull request**

* #74 

**Optionally, what changes should join this PR**

If this solution is accepted, I will need to edit docs reference of `KEY_BACKSPACE`.