### PR TITLE
Fix widget `add_key_command`

### DIFF
--- a/py_cui/widgets.py
+++ b/py_cui/widgets.py
@@ -97,9 +97,9 @@ class Widget(py_cui.ui.UIElement):
 
         if isinstance(key, list):
             for value in key:
-                self._keybindings[value] = command
+                self._key_commands[value] = command
         else:
-            self._keybindings[key] = command
+            self._key_commands[key] = command
 
 
     def add_mouse_command(self, mouse_event: int, command: Callable[[],Any]) -> None:


### PR DESCRIPTION
Just a quick PR to fix a bug I introduced in #154.

I was too quick with the copy/paste and didn't noticed the `_keybindings` attribute was named `_key_commands` in `widgets.py`.

Whoops.