### PR TITLE
Add function for checking if menu widgets are empty

### DIFF
--- a/py_cui/ui.py
+++ b/py_cui/ui.py
@@ -934,7 +934,7 @@ class MenuImplementation(UIImplementation):
             True if menu has no items, False otherwise. Identical to len(self._view_items) == 0
         """
 
-        return self._view_items == 0
+        return len(self._view_items) == 0
 
 
     def set_selected_item(self, selected_item: Any):

--- a/py_cui/ui.py
+++ b/py_cui/ui.py
@@ -925,6 +925,18 @@ class MenuImplementation(UIImplementation):
         return None
 
 
+    def is_empty(self) -> bool:
+        """Function that returns true if menu has no items within it, false otherwise
+
+        Returns
+        -------
+        bool
+            True if menu has no items, False otherwise. Identical to len(self._view_items) == 0
+        """
+
+        return self._view_items == 0
+
+
     def set_selected_item(self, selected_item: Any):
         """Function that replaces the currently selected item with a new item
 

--- a/tests/test_ui_implementations/test_checkbox_imp.py
+++ b/tests/test_ui_implementations/test_checkbox_imp.py
@@ -5,6 +5,14 @@ import py_cui
 elems = ["Elem0", "Elem1", "Elem2", "Elem3", "Elem4"]
 
 
+def test_is_empty(CHECKBOXMENU):
+    scroll = CHECKBOXMENU
+    assert scroll.is_empty()
+    scroll.add_item_list(elems)
+    assert not scroll.is_empty()
+    scroll.clear()
+
+
 def test_add_item_list(CHECKBOXMENU):
     scroll = CHECKBOXMENU
     scroll.add_item_list(elems)

--- a/tests/test_ui_implementations/test_scroll_menu_imp.py
+++ b/tests/test_ui_implementations/test_scroll_menu_imp.py
@@ -6,6 +6,14 @@ import py_cui
 elems = ["Elem0", "Elem1", "Elem2", "Elem3", "Elem4"]
 
 
+def test_is_empty(SCROLLMENU):
+    scroll = SCROLLMENU
+    assert scroll.is_empty()
+    scroll.add_item_list(elems)
+    assert not scroll.is_empty()
+    scroll.clear()
+
+
 def test_add_item_list(SCROLLMENU):
     scroll = SCROLLMENU
     scroll.add_item_list(elems)


### PR DESCRIPTION
Adds simple function for checking if scroll menu or checkbox menu has any items/is empty

- [X] I have read the contribution guidelines
- [X] CI Unit tests pass
- [X] New functions/classes have consistent docstrings

**What this pull request changes**

* Adds `is_empty` function to the `MenuImplementation` superclass
* Adds additional unit tests that test the new function

**Issues fixed with this pull request**

* #142 