### PR TITLE
Update GH Action Python Versions

### DIFF
--- a/.github/workflows/build_docs_test.yml
+++ b/.github/workflows/build_docs_test.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: '3.9'
     - name: Build Docs
       run: |
         cd docs/scripts && bash generateFromDocstrings.sh

--- a/.github/workflows/build_package_test_linux.yml
+++ b/.github/workflows/build_package_test_linux.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: '3.9'
     - name: Update pip
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/build_package_test_win.yml
+++ b/.github/workflows/build_package_test_win.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: '3.9'
     - name: Update pip
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/py_cui_test.yml
+++ b/.github/workflows/py_cui_test.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
Github Actions removes python versions that have reached EOL.

For example: https://github.com/actions/runner-images/issues/12034?utm_source=chatgpt.com

We are updating the actions to a python version that is still supported and available for use in github action. Failing 3.13 test is expected, see #187, will be fixed with #188 

- [ ] I have read the contribution guidelines
- [ ] CI Unit tests pass
- [ ] New functions/classes have consistent docstrings

**What this pull request changes**

* Updates Github Actions Python Versions

